### PR TITLE
feat: allow sandbox to keep active while connected

### DIFF
--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -260,4 +260,28 @@ export class Sandbox extends SandboxSession {
   public async updateHibernationTimeout(timeoutSeconds: number): Promise<void> {
     await this.sandboxClient.updateHibernationTimeout(this.id, timeoutSeconds);
   }
+
+  private keepAliveInterval: NodeJS.Timeout | null = null;
+  /**
+   * If enabled, we will keep the sandbox from hibernating as long as the SDK is connected to it.
+   */
+  public keepActiveWhileConnected(enabled: boolean) {
+    if (enabled && !this.keepAliveInterval) {
+      this.keepAliveInterval = setInterval(() => {
+        this.pitcherClient.clients.system.update();
+      }, 1000 * 30);
+
+      this.onWillDispose(() => {
+        if (this.keepAliveInterval) {
+          clearInterval(this.keepAliveInterval);
+          this.keepAliveInterval = null;
+        }
+      });
+    } else {
+      if (this.keepAliveInterval) {
+        clearInterval(this.keepAliveInterval);
+        this.keepAliveInterval = null;
+      }
+    }
+  }
 }


### PR DESCRIPTION
This allows the user to have a bit more control on when a sandbox hibernates. We essentially ping the sandbox with a keepalive every 30s if this is enabled. This way, the sandbox does not hibernate while the sdk is connected.