### PR TITLE
fix: CommonJS build requires .cjs extension for ESM package

### DIFF
--- a/esbuild.cjs
+++ b/esbuild.cjs
@@ -24,7 +24,8 @@ Promise.all([
     entryPoints: ["src/browser.ts"],
     bundle: true,
     format: "cjs",
-    outdir: "dist/cjs",
+    // .cjs extension is required because "type": "module" is set in package.json
+    outfile: "dist/cjs/browser.cjs",
     platform: "browser",
     plugins: [browserifyPlugin],
   }),
@@ -47,7 +48,8 @@ Promise.all([
     bundle: true,
     format: "cjs",
     platform: "node",
-    outdir: "dist/cjs",
+    // .cjs extension is required because "type": "module" is set in package.json
+    outfile: "dist/cjs/index.cjs",
     plugins: [browserifyPlugin],
   }),
 
@@ -64,7 +66,7 @@ import { createRequire as topLevelCreateRequire } from 'module';
 const require = topLevelCreateRequire(import.meta.url);
       `.trim(),
     },
-    outdir: "dist/esm",
+    outfile: "dist/esm/index.js",
     plugins: [browserifyPlugin],
   }),
 
@@ -72,7 +74,8 @@ const require = topLevelCreateRequire(import.meta.url);
   // CommonJS build
   esbuild.build({
     entryPoints: ["src/index.ts"],
-    outfile: "dist/cjs/index.edge.js",
+    // .cjs extension is required because "type": "module" is set in package.json
+    outfile: "dist/cjs/index.edge.cjs",
     bundle: true,
     format: "cjs",
     platform: "browser",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.1",
       "license": "MIT",
       "bin": {
-        "csb": "dist/bin/codesandbox.js"
+        "csb": "dist/bin/codesandbox.cjs"
       },
       "devDependencies": {
         "@codesandbox/pitcher-client": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
       "types": "./dist/esm/index.d.ts",
       "edge-light": {
         "import": "./dist/esm/index.edge.js",
-        "require": "./dist/cjs/index.edge.js",
-        "default": "./dist/cjs/index.edge.js"
+        "require": "./dist/cjs/index.edge.cjs",
+        "default": "./dist/cjs/index.edge.cjs"
       },
       "worker": {
         "import": "./dist/esm/index.edge.js",
@@ -39,13 +39,14 @@
         "default": "./dist/cjs/index.edge.js"
       },
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "default": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.cjs",
+      "default": "./dist/cjs/index.cjs"
     },
     "./browser": {
       "types": "./dist/esm/browser.d.ts",
       "import": "./dist/esm/browser.js",
-      "require": "./dist/cjs/browser.js"
+      "require": "./dist/cjs/browser.cjs",
+      "default": "./dist/cjs/browser.cjs"
     }
   },
   "types": "./dist/esm/index.d.ts",


### PR DESCRIPTION
The `.js` file extension is treated by Node as the same module type as its nearest package.json. Since `"type": "module"` is set in the SDK, you need to specify the `.cjs` file extension for any cjs output.

Steps to repro:

1. Create a default package.json for any node package, for example:

```
{
  "name": "nodejs-sandbox",
  "version": "1.0.0",
  "main": "index.js",
  "scripts": {
    "start": "node --watch index.js"
  },
  "devDependencies": {},
  "dependencies": {
    "@codesandbox/sdk": "0.6.1"
  }
}
```

2. Use the standard `require("@codesandbox/sdk")` commonjs syntax

3. You'll see this error:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module /project/workspace/node_modules/@codesandbox/sdk/dist/cjs/index.js from /project/workspace/index.js not supported.
/project/workspace/node_modules/@codesandbox/sdk/dist/cjs/index.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead either rename /project/workspace/node_modules/@codesandbox/sdk/dist/cjs/index.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /project/workspace/node_modules/@codesandbox/sdk/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).
```

DevBox with repro: https://codesandbox.io/p/devbox/376c39
