### PR TITLE
fix: don't use env if not env vars are set

### DIFF
--- a/src/shells.ts
+++ b/src/shells.ts
@@ -305,9 +305,11 @@ function runCommandAsUser(
     }
 
     // TODO: use a new shell API that natively supports cwd & env
-    let commandWithEnv = `env ${Object.entries(env ?? {})
-      .map(([key, value]) => `${key}=${value}`)
-      .join(" ")} ${command}`;
+    let commandWithEnv = Object.keys(env ?? {}).length
+      ? `env ${Object.entries(env ?? {})
+          .map(([key, value]) => `${key}=${value}`)
+          .join(" ")} ${command}`
+      : command;
 
     if (cwd) {
       commandWithEnv = `cd ${cwd} && ${commandWithEnv}`;


### PR DESCRIPTION
Fixes https://github.com/codesandbox/codesandbox-sdk/issues/65