### PR TITLE
feat: New release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesandbox/sdk",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "The CodeSandbox SDK",
   "author": "CodeSandbox",
   "license": "MIT",

--- a/src/Sandbox.ts
+++ b/src/Sandbox.ts
@@ -70,41 +70,42 @@ export class Sandbox {
    * new specs without a reboot. Be careful when scaling specs down, if the VM is using more memory
    * than it can scale down to, it can become very slow.
    */
-  async updateTier(sandboxId: string, tier: VMTier): Promise<void> {
+  async updateTier(tier: VMTier): Promise<void> {
     const response = await vmUpdateSpecs({
       client: this.apiClient,
-      path: { id: sandboxId },
+      path: { id: this.id },
       body: {
         tier: tier.name,
       },
     });
 
-    handleResponse(response, `Failed to update sandbox tier ${sandboxId}`);
+    handleResponse(response, `Failed to update sandbox tier ${this.id}`);
   }
 
   /**
    * Updates the hibernation timeout for this sandbox. This is the amount of seconds the sandbox
    * will be kept alive without activity before it is automatically hibernated. Activity can be sessions or interactions with any endpoints exposed by the Sandbox.
    */
-  async updateHibernationTimeout(
-    sandboxId: string,
-    timeoutSeconds: number
-  ): Promise<void> {
+  async updateHibernationTimeout(timeoutSeconds: number): Promise<void> {
     const response = await vmUpdateHibernationTimeout({
       client: this.apiClient,
-      path: { id: sandboxId },
+      path: { id: this.id },
       body: { hibernation_timeout_seconds: timeoutSeconds },
     });
 
     handleResponse(
       response,
-      `Failed to update hibernation timeout for sandbox ${sandboxId}`
+      `Failed to update hibernation timeout for sandbox ${this.id}`
     );
   }
 
   private async createSession(
     opts: SessionCreateOptions
   ): Promise<SandboxSession> {
+    if (opts.id.length > 20) {
+      throw new Error("Session ID must be 32 characters or less");
+    }
+
     const response = await vmCreateSession({
       client: this.apiClient,
       body: {

--- a/src/Sandbox.ts
+++ b/src/Sandbox.ts
@@ -237,6 +237,7 @@ export class Sandbox {
     return {
       id: this.id,
       env: customSession?.env,
+      hostToken: customSession?.hostToken,
       bootupType: this.bootupType,
       cluster: this.cluster,
       latestPitcherVersion: this.pitcherManagerResponse.latestPitcherVersion,

--- a/src/Sandboxes.ts
+++ b/src/Sandboxes.ts
@@ -72,7 +72,7 @@ export class Sandboxes {
     const sandbox = await this.createTemplateSandbox({
       ...opts,
       source: "template",
-      id: this.defaultTemplateId,
+      id: opts.templateId || this.defaultTemplateId,
     });
 
     const session = await sandbox.connect(
@@ -170,6 +170,17 @@ export class Sandboxes {
   }
 
   /**
+   * Forks a sandbox. This will create a new sandbox from the given sandbox.
+   */
+  public async fork(sandboxId: string, opts?: StartSandboxOpts) {
+    return this.create({
+      source: "template",
+      id: sandboxId,
+      ...opts,
+    });
+  }
+
+  /**
    * Restart the sandbox. This will shutdown the sandbox, and then start it again. Files in
    * the project directory (`/project/sandbox`) will be preserved.
    *
@@ -209,6 +220,9 @@ export class Sandboxes {
       }
       case "template": {
         return this.createTemplateSandbox(opts);
+      }
+      default: {
+        throw new Error("Invalid source");
       }
     }
   }

--- a/src/Sandboxes.ts
+++ b/src/Sandboxes.ts
@@ -111,7 +111,7 @@ export class Sandboxes {
     opts: CreateSandboxTemplateSourceOpts & StartSandboxOpts
   ) {
     const templateId = opts.id || this.defaultTemplateId;
-    const privacy = opts.privacy || "public";
+    const privacy = opts.privacy || "unlisted";
     const tags = opts.tags || ["sdk"];
     const path = opts.path || "/SDK";
 

--- a/src/sessions/WebSocketSession/git.ts
+++ b/src/sessions/WebSocketSession/git.ts
@@ -1,4 +1,5 @@
 import type { IPitcherClient } from "@codesandbox/pitcher-client";
+import { Commands } from "./commands";
 
 export class Git {
   /**
@@ -6,12 +7,49 @@ export class Git {
    */
   onStatusChange = this.pitcherClient.clients.git.onStatusUpdated;
 
-  constructor(private pitcherClient: IPitcherClient) {}
+  constructor(
+    private pitcherClient: IPitcherClient,
+    private commands: Commands
+  ) {}
 
   /**
    * Get the current git status.
    */
   status() {
     return this.pitcherClient.clients.git.getStatus();
+  }
+
+  /**
+   * Commit all changes to git
+   */
+  async commit(message: string) {
+    const messageWithQuotesEscaped = message.replace(/"/g, '\\"');
+
+    await this.commands.run([
+      "git add .",
+      `git commit -m "${messageWithQuotesEscaped}"`,
+    ]);
+  }
+
+  /**
+   * Checkout a branch
+   */
+  async checkout(branch: string, isNewBranch = false) {
+    if (isNewBranch) {
+      await this.commands.run([
+        "git checkout -b " + branch,
+        "git push --set-upstream origin " + branch,
+      ]);
+      return;
+    }
+
+    await this.commands.run(["git checkout " + branch]);
+  }
+
+  /**
+   * Push all changes to git
+   */
+  async push() {
+    await this.commands.run(["git push"]);
   }
 }

--- a/src/sessions/WebSocketSession/hosts.ts
+++ b/src/sessions/WebSocketSession/hosts.ts
@@ -1,6 +1,8 @@
 import { IPitcherClient } from "@codesandbox/pitcher-client";
 import { HostToken } from "../../Hosts";
 
+export { HostToken } from "../../Hosts";
+
 export class Hosts {
   constructor(
     private pitcherClient: IPitcherClient,

--- a/src/sessions/WebSocketSession/index.ts
+++ b/src/sessions/WebSocketSession/index.ts
@@ -23,6 +23,7 @@ export * from "./terminals";
 export * from "./commands";
 export * from "./git";
 export * from "./interpreters";
+export * from "./hosts";
 
 export class WebSocketSession {
   private disposable = new Disposable();

--- a/src/sessions/WebSocketSession/index.ts
+++ b/src/sessions/WebSocketSession/index.ts
@@ -55,7 +55,7 @@ export class WebSocketSession {
   /**
    * Namespace for Git operations in the Sandbox
    */
-  public readonly git = new Git(this.pitcherClient);
+  public readonly git: Git;
 
   /**
    * Namespace for managing ports on this Sandbox
@@ -88,6 +88,7 @@ export class WebSocketSession {
 
     this.hosts = new Hosts(this.pitcherClient, hostToken);
     this.interpreters = new Interpreters(this.disposable, this.commands);
+    this.git = new Git(this.pitcherClient, this.commands);
     this.disposable.addDisposable(this.pitcherClient);
   }
 

--- a/src/sessions/WebSocketSession/terminals.ts
+++ b/src/sessions/WebSocketSession/terminals.ts
@@ -2,7 +2,7 @@ import type { protocol, IPitcherClient } from "@codesandbox/pitcher-client";
 import type { Id } from "@codesandbox/pitcher-common";
 import { Disposable } from "../../utils/disposable";
 import { Emitter } from "../../utils/event";
-import { ShellRunOpts } from "./commands";
+import { isCommandShell, ShellRunOpts } from "./commands";
 
 export type ShellSize = { cols: number; rows: number };
 
@@ -72,8 +72,7 @@ export class Terminals {
 
     return shells
       .filter(
-        (shell) =>
-          shell.shellType === "TERMINAL" && !shell.name.startsWith("COMMAND-")
+        (shell) => shell.shellType === "TERMINAL" && !isCommandShell(shell)
       )
       .map((shell) => new Terminal(shell, this.pitcherClient));
   }
@@ -121,6 +120,9 @@ export class Terminal {
     );
   }
 
+  /**
+   * Open the terminal and get its current output, subscribes to future output
+   */
   async open(dimensions = DEFAULT_SHELL_SIZE): Promise<string> {
     const shell = await this.pitcherClient.clients.shell.open(
       this.shell.shellId,

--- a/src/types.ts
+++ b/src/types.ts
@@ -214,6 +214,7 @@ export type CreateSandboxGitSourceOpts = CreateSandboxBaseOpts & {
   source: "git";
   url: string;
   branch: string;
+  templateId?: string;
   config?: {
     accessToken: string;
     email: string;


### PR DESCRIPTION
This PR fixes:

- Bringing back the lost `sdk.sandboxes.fork` method
- Fixed `sandbox.updateTier` and `sandbox.updateHibernationTimeout` to not take `sandboxId`
- Now throwing an error if the `session.id` is longer than 20 characters
- Now allowing you to pass a `templateId` when creating git Sandboxes
- Exposing `name` and `command` on any created Commands
- You can now `command.open()` to get current output, which also subscribes to new outputs if you referenced an existing command
- New git methods of `commit`, `push` and `checkout`
- Fix passing host tokens on browser sessions
- Sandboxes are now by default `unlisted`