### PR TITLE
Fix session create bug when passing in git credentials

### DIFF
--- a/src/Sandboxes.ts
+++ b/src/Sandboxes.ts
@@ -25,6 +25,7 @@ import {
   SandboxListResponse,
   SandboxPrivacy,
   StartSandboxOpts,
+  SessionCreateOptions,
 } from "./types";
 import { PitcherManagerResponse } from "@codesandbox/pitcher-client";
 
@@ -75,21 +76,21 @@ export class Sandboxes {
       id: opts.templateId || this.defaultTemplateId,
     });
 
-    const session = await sandbox.connect(
-      // We do not want users to pass gitAccessToken on global user, because it
-      // can be read by other users
-      {
-        id: "clone-repo-user",
-        permission: "write",
-        ...(opts.config
-          ? {
-              gitAccessToken: opts.config.accessToken,
-              email: opts.config.email,
-              name: opts.config.name,
-            }
-          : {}),
-      }
-    );
+    // We do not want users to pass gitAccessToken on global user, because it
+    // can be read by other users
+    const sessionCreateOptions: SessionCreateOptions = {
+      id: "clone-repo-user",
+      permission: "write",
+    };
+    if (opts.config) {
+      sessionCreateOptions.git = {
+        accessToken: opts.config.accessToken,
+        email: opts.config.email,
+        name: opts.config.name,
+      };
+    }
+
+    const session = await sandbox.connect(sessionCreateOptions);
 
     await session.commands.run([
       "rm -rf .git",


### PR DESCRIPTION
When you create a new sandbox, we were not passing in the right options to the `sandbox.connect`.

This caused a bug If you attempt to use the sdk with a private github repo, creating the sandbox will hang because the github access token won't be set correctly.