### PR TITLE
fix: templates and commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesandbox/sdk",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "The CodeSandbox SDK",
   "author": "CodeSandbox",
   "license": "MIT",

--- a/src/bin/commands/build.ts
+++ b/src/bin/commands/build.ts
@@ -108,6 +108,15 @@ export const buildCommand: yargs.CommandModule<
 
       const sandboxIds = await Promise.all(
         clusters.map(async ({ host: cluster, slug }, index) => {
+          const clusterApiClient: Client = createClient(
+            createConfig({
+              baseUrl: BASE_URL,
+              headers: {
+                Authorization: `Bearer ${API_KEY}`,
+                "x-pitcher-manager-url": `https://${cluster}/api/v1`,
+              },
+            })
+          );
           const sdk = new CodeSandbox(API_KEY, {
             baseUrl: BASE_URL,
             headers: {
@@ -126,7 +135,7 @@ export const buildCommand: yargs.CommandModule<
 
             spinner.start(updateSpinnerMessage(index, "Creating sandbox..."));
             sandboxId = await createSandbox({
-              apiClient,
+              apiClient: clusterApiClient,
               shaTag: tag,
               fromSandbox: argv.fromSandbox,
               collectionPath: argv.path,
@@ -140,10 +149,14 @@ export const buildCommand: yargs.CommandModule<
               updateSpinnerMessage(index, "Starting sandbox...", sandboxId)
             );
 
-            const startResponse = await startVm(apiClient, sandboxId, {
+            const startResponse = await startVm(clusterApiClient, sandboxId, {
               vmTier: VMTier.fromName("Micro"),
             });
-            let sandbox = new Sandbox(sandboxId, apiClient, startResponse);
+            let sandbox = new Sandbox(
+              sandboxId,
+              clusterApiClient,
+              startResponse
+            );
             let session = await sandbox.connect();
 
             spinner.start(

--- a/src/sessions/WebSocketSession/commands.ts
+++ b/src/sessions/WebSocketSession/commands.ts
@@ -64,19 +64,25 @@ export class Commands {
       true
     );
 
+    if (shell.status === "ERROR" || shell.status === "KILLED") {
+      throw new Error(`Failed to create shell: ${shell.buffer.join("\n")}`);
+    }
+
     const details = {
       type: "command",
       command,
       name: opts?.name,
     };
 
-    // Only way for us to differentiate between a command and a terminal
-    this.pitcherClient.clients.shell.rename(
-      shell.shellId,
-      // We embed some details in the name to properly show the command that was run
-      // , the name and that it is an actual command
-      JSON.stringify(details)
-    );
+    if (shell.status !== "FINISHED") {
+      // Only way for us to differentiate between a command and a terminal
+      this.pitcherClient.clients.shell.rename(
+        shell.shellId,
+        // We embed some details in the name to properly show the command that was run
+        // , the name and that it is an actual command
+        JSON.stringify(details)
+      );
+    }
 
     const cmd = new Command(
       this.pitcherClient,

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -56,7 +56,7 @@ export function getDefaultTemplateId(apiClient: Client): string {
     return "7ngcrf";
   }
 
-  return "pcz35m";
+  return "pt_UAYyadeQTA9jw8bXqzgy6v";
 }
 
 export function handleResponse<D, E>(


### PR DESCRIPTION
- Now we properly use the correct cluster header on all calls in the build flow, ensuring deployment of templates
- If a command shell exits during creation, we now properly throw an error
- Now we use a template tag in production for properly deployed universal templates