### PR TITLE
call `onStatusChangeEmitter` on `status` change

### DIFF
--- a/src/sessions/WebSocketSession/commands.ts
+++ b/src/sessions/WebSocketSession/commands.ts
@@ -162,7 +162,18 @@ export class Command {
   /**
    * The status of the command.
    */
-  status: CommandStatus = "RUNNING";
+  #status: CommandStatus = "RUNNING";
+
+  get status(): CommandStatus {
+    return this.#status;
+  }
+
+  set status(value: CommandStatus) {
+    if (this.#status !== value) {
+      this.#status = value;
+      this.onStatusChangeEmitter.fire(this.#status);
+    }
+  }
 
   /**
    * The command that was run


### PR DESCRIPTION
`onStatusChange` wasn't firing any status changes because `onStatusChangeEmitter` was never fired
This PR adds custom setter for a `status` variable, so `onStatusChangeEmitter` can be triggered on every variable change