### PR TITLE
docs: fix broken code examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,46 +27,38 @@ Create an API token by going to https://codesandbox.io/t/api, and clicking on th
 ```javascript
 import { CodeSandbox } from "@codesandbox/sdk";
 
-// Create the client with your token
-const sdk = new CodeSandbox(token);
+// Create the client
+const sdk = new CodeSandbox.CodeSandbox(process.env.CSB_API_KEY!);
 
 // This creates a new sandbox by forking our default template sandbox.
 // You can also pass in other template ids, or create your own template to fork from.
-const sandbox = await sdk.sandbox.create();
+const sandbox = await sdk.sandboxes.create();
+const session = await sandbox.connect();
 
 // You can run JS code directly
-await sandbox.shells.js.run("console.log(1+1)");
-// Or Python code (if it's installed in the template)
-await sandbox.shells.python.run("print(1+1)");
+await session.interpreters.javascript("'Hello from Node.js!'");
+// Or Python code
+await session.interpreters.python("'Hello from Python!'");
 
 // Or anything else
-await sandbox.shells.run("echo 'Hello, world!'");
+await session.commands.run("echo 'Hello, world!'");
 
 // We have a FS API to interact with the filesystem
-await sandbox.fs.writeTextFile("./hello.txt", "world");
+await session.fs.writeTextFile("./hello.txt", "world");
 
 // And you can clone sandboxes! This does not only clone the filesystem, processes that are running in the original sandbox will also be cloned!
-const sandbox2 = await sandbox.fork();
+const sandbox2 = await sdk.sandboxes.fork(sandbox.id);
+const session2 = await sandbox2.connect();
 
 // Check that the file is still there
-await sandbox2.fs.readTextFile("./hello.txt");
+await session2.fs.readTextFile("./hello.txt");
 
 // You can also get the opened ports, with the URL to access those
-console.log(sandbox2.ports.getOpenedPorts());
-
-// Getting metrics...
-const metrics = await sandbox2.getMetrics();
-console.log(
-  `Memory: ${metrics.memory.usedKiB} KiB / ${metrics.memory.totalKiB} KiB`
-);
-console.log(`CPU: ${(metrics.cpu.used / metrics.cpu.cores) * 100}%`);
+console.log(session2.ports.getAll());
 
 // Finally, you can hibernate a sandbox. This will snapshot the sandbox and stop it. Next time you start the sandbox, it will continue where it left off, as we created a memory snapshot.
-await sandbox.hibernate();
-await sandbox2.hibernate();
-
-// Open the sandbox again
-const resumedSandbox = await sdk.sandbox.open(sandbox.id);
+await sdk.sandboxes.hibernate(sandbox.id);
+await sdk.sandboxes.hibernate(sandbox2.id);
 ```
 
 ## CodeSandbox Integration


### PR DESCRIPTION
I've fixed the examples in the README which were out of date.