### PR TITLE
chore: remove reference to (unsupported) TOGETHER_API_KEY

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -25,6 +25,6 @@ export function getInferredApiKey() {
     typeof process !== "undefined"
       ? process.env?.CSB_API_KEY || process.env?.TOGETHER_API_KEY
       : undefined,
-    "CSB_API_KEY or TOGETHER_API_KEY is not set"
+    "CSB_API_KEY is not set"
   );
 }


### PR DESCRIPTION
We don't fully support using a `TOGETHER_API_KEY` yet, so I've removed the reference.