### PR TITLE
fix: timeout errors on keepActiveWhileConnected

### DIFF
--- a/src/SandboxClient/index.ts
+++ b/src/SandboxClient/index.ts
@@ -271,7 +271,9 @@ export class SandboxClient {
     if (enabled) {
       if (!this.keepAliveInterval) {
         this.keepAliveInterval = setInterval(() => {
-          this.agentClient.system.update();
+          this.agentClient.system.update().catch(() => {
+            // We do not care about errors here
+          })
         }, 1000 * 30);
       }
     } else {


### PR DESCRIPTION
Currently users can see errors on the "keepActiveWhileConnected" as we never catch those errors.