### PR TITLE
feat: add efficient sandbox retrieval methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,35 @@ const output = await client.commands.run("echo 'Hello World'");
 console.log(output); // Hello World
 ```
 
+## Efficient Sandbox Retrieval
+
+When you need to retrieve metadata for specific sandboxes by their IDs, you can use the efficient retrieval methods instead of listing and filtering all sandboxes:
+
+### Get Single Sandbox
+
+```javascript
+// Efficient single sandbox retrieval
+const sandbox = await sdk.sandboxes.getSandbox("sandbox-id");
+console.log(sandbox.title, sandbox.tags);
+```
+
+### Get Multiple Sandboxes
+
+```javascript
+// Efficient multiple sandbox retrieval
+const result = await sdk.sandboxes.getSandboxes({
+  ids: ["sandbox-1", "sandbox-2", "sandbox-3"],
+  continueOnError: true // Continue even if some IDs fail
+});
+
+console.log(`Retrieved ${result.sandboxes.length} sandboxes`);
+if (result.errors?.length) {
+  console.log(`Failed to retrieve ${result.errors.length} sandboxes`);
+}
+```
+
+These methods are significantly more efficient than using `list()` and filtering, especially for large organizations with thousands of sandboxes.
+
 ## Configuration
 
 The SDK supports the following environment variables for configuration:

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,27 @@ export type SandboxListOpts = {
   status?: "running";
 };
 
+export type GetSandboxesOpts = {
+  /**
+   * List of sandbox IDs to retrieve metadata for
+   */
+  ids: string[];
+  /**
+   * If true, continue processing even if some sandbox IDs fail to retrieve.
+   * Failed retrievals will be included in the errors array.
+   * @default true
+   */
+  continueOnError?: boolean;
+};
+
+export interface GetSandboxesResponse {
+  sandboxes: SandboxInfo[];
+  errors?: Array<{
+    id: string;
+    error: string;
+  }>;
+}
+
 export interface SandboxListResponse {
   sandboxes: SandboxInfo[];
   hasMore: boolean;


### PR DESCRIPTION
Add getSandbox() and getSandboxes() methods to retrieve specific sandboxes by ID without listing all sandboxes, solving performance issues for large organizations.

- Add getSandbox(sandboxId) for single sandbox retrieval
- Add getSandboxes(opts) for bulk retrieval with parallel requests
- Support error handling with continueOnError option
- Include comprehensive TypeScript types and JSDoc
- Update README with usage examples

This addresses the performance bottleneck when retrieving metadata for known sandbox IDs in organizations with thousands of sandboxes.

🤖 Generated with [Claude Code](https://claude.ai/code)