### PR TITLE
fix: Add custom retry delay support for startVM API calls

### DIFF
--- a/src/API.ts
+++ b/src/API.ts
@@ -48,7 +48,7 @@ import type {
   VmCreateSessionData,
   VmShutdownData,
   VmUpdateSpecsData,
-  VmStartData,
+  VmStartRequest,
   VmUpdateSpecs2Data,
   PreviewHostListData,
   PreviewHostCreateData,
@@ -109,6 +109,10 @@ export interface APIOptions {
   apiKey: string;
   config?: Config;
   instrumentation?: (request: Request) => Promise<Response>;
+}
+
+export interface StartVmOptions extends VmStartRequest {
+  retryDelay?: number;
 }
 
 export class API {
@@ -353,7 +357,8 @@ export class API {
     return handleResponse(response, `Failed to update specs for VM ${id}`);
   }
 
-  async startVm(id: string, data?: VmStartData["body"], retryDelay: number = 200) {
+  async startVm(id: string, options?: StartVmOptions) {
+    const { retryDelay = 200, ...data } = options || {};
     const response = await retryWithDelay(
       () =>
         vmStart({

--- a/src/Sandbox.ts
+++ b/src/Sandbox.ts
@@ -127,7 +127,7 @@ export class Sandbox {
   ) {
     const client = await SandboxClient.create(
       session, 
-      async () => this.getSession(await this.api.startVm(this.id, undefined, 200), customSession),
+      async () => this.getSession(await this.api.startVm(this.id, { retryDelay: 200 }), customSession),
       undefined,
       this.tracer
     );
@@ -241,7 +241,7 @@ export class Sandbox {
               client ||
               SandboxClient.create(
                 session, 
-                async () => this.getSession(await this.api.startVm(this.id, undefined, 200), customSession),
+                async () => this.getSession(await this.api.startVm(this.id, { retryDelay: 200 }), customSession),
                 undefined,
                 this.tracer
               )

--- a/src/Sandboxes.ts
+++ b/src/Sandboxes.ts
@@ -88,8 +88,7 @@ export class Sandboxes {
 
     const startResponse = await this.api.startVm(
       sandbox.id,
-      getStartOptions(opts),
-      200 // Keep 200ms delay for creation
+      { ...getStartOptions(opts), retryDelay: 200 } // Keep 200ms delay for creation
     );
 
     return new Sandbox(sandbox.id, this.api, startResponse, this.tracer);
@@ -109,7 +108,7 @@ export class Sandboxes {
       "sandboxes.resume",
       { "sandbox.id": sandboxId },
       async () => {
-        const startResponse = await this.api.startVm(sandboxId, undefined, 500); // Use 500ms delay for resume
+        const startResponse = await this.api.startVm(sandboxId, { retryDelay: 500 }); // Use 500ms delay for resume
         return new Sandbox(sandboxId, this.api, startResponse, this.tracer);
       }
     );
@@ -163,7 +162,7 @@ export class Sandboxes {
         }
 
         try {
-          const startResponse = await this.api.startVm(sandboxId, opts, 1000); // Use 1000ms delay for restart
+          const startResponse = await this.api.startVm(sandboxId, { ...opts, retryDelay: 1000 }); // Use 1000ms delay for restart
 
           return new Sandbox(sandboxId, this.api, startResponse, this.tracer);
         } catch (e) {

--- a/src/bin/commands/build.ts
+++ b/src/bin/commands/build.ts
@@ -187,7 +187,7 @@ export const buildCommand: yargs.CommandModule<
           spinner.start(updateSpinnerMessage(index, "Starting sandbox..."));
 
           const startResponse = await withCustomError(
-            api.startVm(id, undefined, 200),
+            api.startVm(id, { retryDelay: 200 }),
             "Failed to start sandbox at all"
           );
           let sandboxVM = new Sandbox(id, api, startResponse);


### PR DESCRIPTION
- Added retryDelay parameter to startVm method with default 200ms
- Sandbox creation: uses 200ms delay (preserves existing behavior)
- Sandbox restart: uses 1000ms delay for better stability
- Sandbox resume: uses 500ms delay for hibernated sandboxes
- Connection fallbacks: use 200ms delay for reconnection scenarios