### PR TITLE
fix: handle isomorphic-ws building

### DIFF
--- a/esbuild.cjs
+++ b/esbuild.cjs
@@ -83,8 +83,13 @@ const nodeClientEsmBuild = esbuild.build({
   bundle: true,
   format: "esm",
   outfile: "dist/esm/node.js",
+  // Handle dynamic requires (WS)
+  banner: {
+    js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`,
+  },
   platform: "node",
-  external: externalModules,
+  // These has to be optional deps, due to being native and only working in certain envs
+  external: externalModules.concat("bufferutil", "utf-8-validate"),
 });
 
 /**
@@ -107,8 +112,13 @@ const sdkEsmBuild = esbuild.build({
   format: "esm",
   define,
   platform: "node",
+  // Handle dynamic requires (WS)
+  banner: {
+    js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`,
+  },
   outfile: "dist/esm/index.js",
-  external: externalModules,
+  // These has to be optional deps, due to being native and only working in certain envs
+  external: externalModules.concat("bufferutil", "utf-8-validate"),
 });
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "cli-table3": "^0.6.3",
         "date-fns": "^4.1.0",
         "isbinaryfile": "^5.0.4",
-        "isomorphic-ws": "^5.0.0",
         "ora": "^8.2.0",
         "path": "^0.12.7",
         "readline": "^1.3.0",
@@ -42,6 +41,7 @@
         "esbuild": "^0.25.0",
         "ignore": "^6.0.2",
         "ink": "^6.1.0",
+        "isomorphic-ws": "^5.0.0",
         "os-browserify": "^0.3.0",
         "path-browserify": "^1.0.1",
         "prettier": "^2.2.1",
@@ -53,7 +53,9 @@
         "why-is-node-running": "^2.3.0"
       },
       "optionalDependencies": {
-        "@sentry/node": "^9.29.0"
+        "@sentry/node": "^9.29.0",
+        "bufferutil": "^4.0.0",
+        "utf-8-validate": "^6.0.0"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -2161,6 +2163,20 @@
         "node": ">=0.2.0"
       }
     },
+    "node_modules/bufferutil": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.9.tgz",
+      "integrity": "sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/c12": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/c12/-/c12-2.0.1.tgz",
@@ -3840,6 +3856,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
       "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "ws": "*"
@@ -4258,6 +4275,18 @@
       "integrity": "sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/nopt": {
       "version": "2.1.2",
@@ -5467,6 +5496,20 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/utf-8-validate": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.5.tgz",
+      "integrity": "sha512-EYZR+OpIXp9Y1eG1iueg8KRsY8TuT8VNgnanZ0uA3STqhHQTLwbl+WX76/9X5OY12yQubymBpaBSmMPkSTQcKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/util": {
       "version": "0.12.5",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
     "semver": "^6.3.0",
     "tslib": "^2.1.0",
     "typescript": "^5.7.2",
-    "why-is-node-running": "^2.3.0"
+    "why-is-node-running": "^2.3.0",
+    "isomorphic-ws": "^5.0.0"
   },
   "dependencies": {
     "@hey-api/client-fetch": "^0.7.3",
@@ -102,7 +103,6 @@
     "cli-table3": "^0.6.3",
     "date-fns": "^4.1.0",
     "isbinaryfile": "^5.0.4",
-    "isomorphic-ws": "^5.0.0",
     "ora": "^8.2.0",
     "path": "^0.12.7",
     "readline": "^1.3.0",
@@ -110,6 +110,8 @@
     "yargs": "^17.7.2"
   },
   "optionalDependencies": {
-    "@sentry/node": "^9.29.0"
+    "@sentry/node": "^9.29.0",
+    "bufferutil": "^4.0.0",
+    "utf-8-validate": "^6.0.0"
   }
 }


### PR DESCRIPTION
Because of CJS/ESM hell when trying to build code in user land, we have to include `isomorphic-ws` in the build of the Node/SDK code. We do this by making it a dev dependency. But they rely on a dynamic check for `bufferutil` and `utf-8-validate` which requires the addition of a `createRequire` in the ESM build.

`bufferutil` and `utf-8-validate` can not be bundled in as they are native bundles that does not work in all environments, but can be installed in user land to optimize the WS. 

We should really document this optimization.