### PR TITLE
fix: Queue messages on lost connection and reconnect also on hibernation

### DIFF
--- a/src/SandboxClient/index.ts
+++ b/src/SandboxClient/index.ts
@@ -190,12 +190,7 @@ export class SandboxClient {
         }
         this.keepAliveInterval = null;
 
-        // Only attempt auto-reconnect on DISCONNECTED, not HIBERNATED, and not if disposed
-        if (
-          state === "DISCONNECTED" &&
-          !this.isExplicitlyDisconnected &&
-          !this.disposable.isDisposed
-        ) {
+        if (!this.isExplicitlyDisconnected && !this.disposable.isDisposed) {
           this.attemptAutoReconnect();
         }
       } else if (state === "CONNECTED") {

--- a/src/SandboxClient/index.ts
+++ b/src/SandboxClient/index.ts
@@ -190,7 +190,12 @@ export class SandboxClient {
         }
         this.keepAliveInterval = null;
 
-        if (!this.isExplicitlyDisconnected && !this.disposable.isDisposed) {
+        // Only attempt auto-reconnect on DISCONNECTED, not HIBERNATED, and not if disposed
+        if (
+          state === "DISCONNECTED" &&
+          !this.isExplicitlyDisconnected &&
+          !this.disposable.isDisposed
+        ) {
           this.attemptAutoReconnect();
         }
       } else if (state === "CONNECTED") {


### PR DESCRIPTION
So currently users can get a CLOSED state error when trying to send messages. The reason for this is that for some reason the websocket connection is closed, which can be for different reasons:

- Hibernation
- Latency in health checks
- Other environment related issues

In this PR we always queue messages if not able to send the message. Can be tested with:

```ts
import { CodeSandbox } from "./dist/esm";

const sdk = new CodeSandbox();

console.log("creating sandbox...");
const sandbox = await sdk.sandboxes.create();

console.log("Created sandbox " + sandbox.id + ", connecting...");

const client = await sandbox.connect();

console.log("Connected");

client.disconnect();

client.fs.writeTextFile("test.txt", "hello ther!").then(() => {
  console.log("FILE WRITTEN");
});

setTimeout(() => {
  console.log("REconnect");
  client.reconnect();
}, 2000);

```