### PR TITLE
fix: ensure private preview on private sandbox

### DIFF
--- a/src/Sandboxes.ts
+++ b/src/Sandboxes.ts
@@ -397,7 +397,7 @@ function mapPrivacyForApi(privacy: SandboxPrivacy): {
     case "unlisted":
       return { mappedPrivacy: 1 }; // Keep as unlisted
     case "private":
-      return { mappedPrivacy: 2 }; // Keep as private
+      return { mappedPrivacy: 2, privatePreview: true }; // Keep as private
     case "public":
       return { mappedPrivacy: 1 }; // Map to unlisted
     case "public-hosts":


### PR DESCRIPTION
We currently inherit the `private_preview` from the parent. We have to explicitly pass the correct value. 