### PR TITLE
fix: stop adding ignore file names to ignore list during template bui…

### DIFF
--- a/src/bin/utils/files.ts
+++ b/src/bin/utils/files.ts
@@ -14,7 +14,6 @@ export async function hashDirectory(dirPath: string): Promise<string[]> {
     const fullPath = join(dirPath, file);
     if (existsSync(fullPath)) {
       ig.add(readFileSync(fullPath, "utf8"));
-      ig.add(file);
     }
   });
 


### PR DESCRIPTION
…lding

Previously, when processing ignore files (.gitignore, .dockerignore, .csbignore) during template building, the code was incorrectly adding both:
1. The contents of the ignore files (correct behavior)
2. The ignore file names themselves (incorrect behavior)

This meant that .gitignore, .dockerignore, and .csbignore files were being excluded from templates when they should be included. Only the patterns INSIDE these files should be used to determine what to ignore.