### PR TITLE
fix: handle spacing in env variables of commands

### DIFF
--- a/src/SandboxClient/commands.ts
+++ b/src/SandboxClient/commands.ts
@@ -106,7 +106,10 @@ export class SandboxCommands {
           ? `source $HOME/.private/.env 2>/dev/null || true && env ${Object.entries(
               passedEnv
             )
-              .map(([key, value]) => `${key}=${value}`)
+              .map(([key, value]) => {
+                const escapedValue = String(value).replace(/'/g, "'\\''");
+                return `${key}='${escapedValue}'`;
+              })
               .join(" ")} bash -c '${escapedCommand}'`
           : `source $HOME/.private/.env 2>/dev/null || true && bash -c '${escapedCommand}'`;
 


### PR DESCRIPTION
Can be tested with:

```ts
import { CodeSandbox } from "@codesandbox/sdk";

const sdk = new CodeSandbox();
//   "csb_v1_uv6a0J6nM43YEMkqJ2RE3T8fuFGmPKsnkZEUkhCBbcU",
/*{
    baseUrl: "https://api.codesandbox.stream",
  }*/

console.log("Creating sandbox...");
let sandbox = await sdk.sandboxes.create();
const client = await sandbox.connect();
console.log(`Created sandbox with ID: ${sandbox.id}`);

const env = {
  GIT_AUTHOR_NAME: "First Last",
  GIT_AUTHOR_EMAIL: "test@company.com",
};

console.log(await client.commands.run("echo $GIT_AUTHOR_NAME", { env }));

```