### PR TITLE
feat: command error with exit code

### DIFF
--- a/src/SandboxClient/commands.ts
+++ b/src/SandboxClient/commands.ts
@@ -26,6 +26,33 @@ export type CommandStatus =
   | "KILLED"
   | "RESTARTING";
 
+/**
+ * Error thrown when a command fails with a non-zero exit code.
+ */
+export class CommandError extends Error {
+  /**
+   * The exit code returned by the command.
+   */
+  exitCode: number;
+
+  /**
+   * The output produced by the command.
+   */
+  output: string;
+
+  constructor(message: string, exitCode: number, output: string) {
+    super(message);
+    this.name = "CommandError";
+    this.exitCode = exitCode;
+    this.output = output;
+
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, CommandError);
+    }
+  }
+}
+
 const DEFAULT_SHELL_SIZE = { cols: 128, rows: 24 };
 
 // This can not be called Commands due to React Native
@@ -242,6 +269,11 @@ export class Command {
    */
   #status: CommandStatus = "RUNNING";
 
+  /**
+   * The exit code of the command, available after it completes.
+   */
+  private exitCode?: number;
+
   get status(): CommandStatus {
     return this.#status;
   }
@@ -276,6 +308,7 @@ export class Command {
     this.disposable.addDisposable(
       agentClient.shells.onShellExited(({ shellId, exitCode }) => {
         if (shellId === this.shell.shellId) {
+          this.exitCode = exitCode;
           this.status = exitCode === 0 ? "FINISHED" : "ERROR";
           this.barrier.open();
         }
@@ -390,7 +423,11 @@ export class Command {
           return cleaned;
         }
 
-        throw new Error(`Command ERROR: ${cleaned}`);
+        throw new CommandError(
+          `Command failed with exit code ${this.exitCode ?? "unknown"}`,
+          this.exitCode ?? 1,
+          cleaned
+        );
       }
     );
   }


### PR DESCRIPTION
Can be tested with:

```ts
import { CodeSandbox } from "@codesandbox/sdk";

const sdk = new CodeSandbox();
//   "csb_v1_uv6a0J6nM43YEMkqJ2RE3T8fuFGmPKsnkZEUkhCBbcU",
/*{
    baseUrl: "https://api.codesandbox.stream",
  }*/

console.log("Creating sandbox...");
let sandbox = await sdk.sandboxes.create();
const client = await sandbox.connect();
console.log(`Created sandbox with ID: ${sandbox.id}`);

try {
  await client.commands.run("npm run nonexistent-script");
} catch (error) {
  console.log("Exit code:", error.exitCode);
}

```

⚠️ We need to update the docs here!!!