### PR TITLE
fix: replace heartbeat with keep alive

### DIFF
--- a/src/AgentClient/AgentConnection.ts
+++ b/src/AgentClient/AgentConnection.ts
@@ -93,19 +93,6 @@ export class AgentConnection {
     connection.onDisconnected(() => {
       this.state = "DISCONNECTED";
     });
-
-    connection.onMissingHeartbeat(() => {
-      // Be more conservative about disconnection - only disconnect if we have no activity
-      // and no pending messages, indicating a truly dead connection
-      if (this.pendingMessages.size === 0) {
-        // Add a small delay to allow for network recovery before declaring disconnection
-        setTimeout(() => {
-          if (this.pendingMessages.size === 0 && this.state === "CONNECTED") {
-            this.state = "DISCONNECTED";
-          }
-        }, 1000);
-      }
-    });
   }
 
   onNotification<T extends PitcherNotification["method"]>(

--- a/src/AgentClient/index.ts
+++ b/src/AgentClient/index.ts
@@ -19,9 +19,8 @@ import {
   PickRawFsResult,
 } from "../agent-client-interface";
 import { AgentConnection } from "./AgentConnection";
-import { Emitter, Event } from "../utils/event";
+import { Emitter } from "../utils/event";
 import { DEFAULT_SUBSCRIPTIONS, SandboxSession } from "../types";
-import { SandboxClient } from "../SandboxClient";
 import { InitStatus } from "../pitcher-protocol/messages/system";
 
 // Timeout for detecting a pong response, leading to a forced disconnect
@@ -414,9 +413,6 @@ export class AgentClient implements IAgentClient {
     // Connection is fully established after successful client/join
     agentConnection.state = "CONNECTED";
 
-    // Now that we have initialized we set an appropriate timeout to more efficiently detect disconnects
-    agentConnection.connection.setPongDetectionTimeout(PONG_DETECTION_TIMEOUT);
-
     return {
       client: new AgentClient(getSession, agentConnection, {
         sandboxId: session.sandboxId,
@@ -457,9 +453,6 @@ export class AgentClient implements IAgentClient {
     this.workspacePath = params.workspacePath;
     this.isUpToDate = params.isUpToDate;
     this.reconnectToken = params.reconnectToken;
-  }
-  ping() {
-    this.agentConnection.connection.ping(FOCUS_PONG_DETECTION_TIMEOUT);
   }
   async disconnect(): Promise<void> {
     await this.agentConnection.disconnect();

--- a/src/agent-client-interface.ts
+++ b/src/agent-client-interface.ts
@@ -139,7 +139,6 @@ export interface IAgentClient {
   setup: IAgentClientSetup;
   tasks: IAgentClientTasks;
   system: IAgentClientSystem;
-  ping(): void;
   disconnect(): Promise<void>;
   reconnect(): Promise<void>;
   dispose(): void;

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -43,11 +43,7 @@ export async function connectToSandbox({
   onFocusChange((isFocused) => {
     // We immediately ping the connection when focusing, so that
     // we detect a disconnect as early as possible
-    if (isFocused && client.state === "CONNECTED") {
-      client["agentClient"].ping();
-      // If we happen to be disconnected when focusing we try to reconnect, but only if we are currently
-      // hibernated and we did not do a manual disconnect
-    } else if (
+    if (
       isFocused &&
       (client.state === "DISCONNECTED" || client.state === "HIBERNATED")
     ) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,16 +100,16 @@ export const DEFAULT_SUBSCRIPTIONS = {
     status: true,
   },
   file: {
-    status: true,
-    selection: true,
-    ot: true,
+    status: false,
+    selection: false,
+    ot: false,
   },
   fs: {
-    operations: true,
+    operations: false,
   },
   git: {
-    status: true,
-    operations: true,
+    status: false,
+    operations: false,
   },
   port: {
     status: true,
@@ -121,7 +121,7 @@ export const DEFAULT_SUBSCRIPTIONS = {
     status: true,
   },
   system: {
-    metrics: true,
+    metrics: false,
   },
 };
 


### PR DESCRIPTION
So initially the SDK connection stability was implemented to deal with browser issues. Things like unfocusing the tab and detecting disconnect immediately when you refocus after hibernation etc. This was done with an empty ping/pong message and detecting lack of pong detection.

Now the users or on the edge there are other challenges. Things like hibernated processes like Vercel Fluid Compute and CloudFlare Workflows. In this case it is important that heartbeats has payload and they need to be more aggressive.

Instead of having two mechanisms for "keep alive" (one at SDK interface level and one internal heartbeat for the websocket) we now only rely on the explicit `keepActiveWhileConnected` logic. This sends an actual payload every 10 seconds to Pitcher. Previously this was by default `false`, but is now default `true`.

Additionally I noticed the SDK subscribes to data like git status and metrics from Pitcher. Data that we are not exposing in any way and just adds unnecessary processing on Pitcher. 