### PR TITLE
feat: add SDK-based benchmark for time to port ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.4.2](https://github.com/codesandbox/codesandbox-sdk/compare/v2.4.1...v2.4.2) (2025-12-04)
+
+
+### Bug Fixes
+
+* send params to restart correctly ([#232](https://github.com/codesandbox/codesandbox-sdk/issues/232)) ([c9775c4](https://github.com/codesandbox/codesandbox-sdk/commit/c9775c43eecdda38b3c7ea309e03610edeb73b0f))
+
 ## [2.4.1](https://github.com/codesandbox/codesandbox-sdk/compare/v2.4.0...v2.4.1) (2025-10-23)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codesandbox/sdk",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codesandbox/sdk",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "@hey-api/client-fetch": "^0.13.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -927,9 +927,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.34.0.tgz",
-      "integrity": "sha512-aKcOkyrorBGlajjRdVoJWHTxfxO1vCNHLJVlSDaRHDIdjU+pX8IYQPvPDkYiujKLbRnWU+1TBwEt0QRgSm4SGA==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
       "optional": true,
       "engines": {
@@ -1822,9 +1822,9 @@
       }
     },
     "node_modules/bufferutil": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.9.tgz",
-      "integrity": "sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5649,9 +5649,9 @@
       "license": "MIT"
     },
     "node_modules/utf-8-validate": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.5.tgz",
-      "integrity": "sha512-EYZR+OpIXp9Y1eG1iueg8KRsY8TuT8VNgnanZ0uA3STqhHQTLwbl+WX76/9X5OY12yQubymBpaBSmMPkSTQcKA==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
+      "integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesandbox/sdk",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "The CodeSandbox SDK",
   "author": "CodeSandbox",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "clean": "rimraf ./dist",
     "test": "vitest",
     "test:e2e": "vitest run tests/e2e",
+    "benchmark": "npx tsx scripts/benchmark-port-ready.ts",
     "typecheck": "tsc --noEmit",
     "format": "prettier '**/*.{md,js,jsx,json,ts,tsx}' --write",
     "postbuild": "rimraf {lib,es}/**/__tests__ {lib,es}/**/*.{spec,test}.{js,d.ts,js.map}",

--- a/scripts/benchmark-port-ready.ts
+++ b/scripts/benchmark-port-ready.ts
@@ -1,0 +1,148 @@
+/**
+ * Benchmark: Time to port ready
+ *
+ * Measures how long it takes from sandbox creation until a specific port is
+ * ready on the sandbox. Run with different template IDs to compare pint vs pitcher.
+ *
+ * Usage:
+ *   CSB_API_KEY=<key> CSB_TEMPLATE_ID=<id> CSB_PORT=3000 npx tsx scripts/benchmark-port-ready.ts
+ *
+ * Environment variables:
+ *   CSB_API_KEY         - CodeSandbox API key (required)
+ *   CSB_TEMPLATE_ID     - Template ID to fork sandboxes from (required)
+ *   CSB_PORT            - Port number to wait for (default: 3000)
+ *   CSB_RUNS            - Number of benchmark runs (default: 10)
+ *   CSB_PORT_TIMEOUT_MS - Timeout waiting for port in ms (default: 120000)
+ */
+
+import { CodeSandbox } from '../src/index.js';
+
+const API_KEY = process.env.CSB_API_KEY;
+const TEMPLATE_ID = process.env.CSB_TEMPLATE_ID;
+const PORT = parseInt(process.env.CSB_PORT ?? '3000', 10);
+const RUNS = parseInt(process.env.CSB_RUNS ?? '10', 10);
+const PORT_TIMEOUT_MS = parseInt(process.env.CSB_PORT_TIMEOUT_MS ?? '120000', 10);
+
+if (!API_KEY) {
+  console.error('Error: CSB_API_KEY environment variable is required');
+  process.exit(1);
+}
+if (!TEMPLATE_ID) {
+  console.error('Error: CSB_TEMPLATE_ID environment variable is required');
+  process.exit(1);
+}
+
+async function measureRun(
+  sdk: CodeSandbox,
+  runIndex: number
+): Promise<number> {
+  const start = Date.now();
+  let sandboxId: string | undefined;
+
+  try {
+    const sandbox = await sdk.sandboxes.create({ id: TEMPLATE_ID });
+    sandboxId = sandbox.id;
+
+    const client = await sandbox.connect();
+    try {
+      await client.ports.waitForPort(PORT, { timeoutMs: PORT_TIMEOUT_MS });
+      return Date.now() - start;
+    } finally {
+      try {
+        await client.disconnect();
+        client.dispose();
+      } catch {
+        // best effort
+      }
+    }
+  } finally {
+    if (sandboxId) {
+      try {
+        await sdk.sandboxes.shutdown(sandboxId);
+      } catch {
+        // sandbox may already be stopped
+      }
+      try {
+        await sdk.sandboxes.delete(sandboxId);
+      } catch (e) {
+        console.error(`  Warning: failed to delete sandbox ${sandboxId}:`, e);
+      }
+    }
+  }
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 1) return sorted[0];
+  const index = (p / 100) * (sorted.length - 1);
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  if (lower === upper) return sorted[lower];
+  return sorted[lower] + (sorted[upper] - sorted[lower]) * (index - lower);
+}
+
+function fmt(ms: number): string {
+  return `${ms.toFixed(0)}ms (${(ms / 1000).toFixed(2)}s)`;
+}
+
+async function main() {
+  const sdk = new CodeSandbox(API_KEY!);
+  const results: number[] = [];
+  const failures: number[] = [];
+
+  console.log('='.repeat(56));
+  console.log('  CodeSandbox SDK Benchmark: Time to Port Ready');
+  console.log('='.repeat(56));
+  console.log(`  Template ID : ${TEMPLATE_ID}`);
+  console.log(`  Port        : ${PORT}`);
+  console.log(`  Runs        : ${RUNS}`);
+  console.log(`  Timeout     : ${PORT_TIMEOUT_MS}ms`);
+  console.log('='.repeat(56));
+
+  for (let i = 0; i < RUNS; i++) {
+    process.stdout.write(`\nRun ${i + 1}/${RUNS} ... `);
+    try {
+      const elapsed = await measureRun(sdk, i);
+      results.push(elapsed);
+      console.log(`${fmt(elapsed)}`);
+    } catch (e) {
+      failures.push(i + 1);
+      console.log(`FAILED`);
+      console.error(`  Error:`, e instanceof Error ? e.message : e);
+    }
+  }
+
+  console.log('\n' + '='.repeat(56));
+  console.log(`Results  (${results.length} succeeded, ${failures.length} failed)`);
+  console.log('='.repeat(56));
+
+  if (failures.length > 0) {
+    console.log(`  Failed runs: ${failures.join(', ')}`);
+  }
+
+  if (results.length === 0) {
+    console.error('  All runs failed — no statistics available.');
+    process.exit(1);
+  }
+
+  results.forEach((ms, i) => {
+    console.log(`  Run ${String(i + 1).padStart(2)}: ${fmt(ms)}`);
+  });
+
+  const sorted = [...results].sort((a, b) => a - b);
+  const avg = results.reduce((a, b) => a + b, 0) / results.length;
+
+  console.log('\nStatistics:');
+  console.log(`  Min     : ${fmt(sorted[0])}`);
+  console.log(`  Max     : ${fmt(sorted[sorted.length - 1])}`);
+  console.log(`  Average : ${fmt(avg)}`);
+  console.log(`  Median  : ${fmt(percentile(sorted, 50))}`);
+  console.log(`  p90     : ${fmt(percentile(sorted, 90))}`);
+  console.log(`  p95     : ${fmt(percentile(sorted, 95))}`);
+  console.log(`  p99     : ${fmt(percentile(sorted, 99))}`);
+  console.log('='.repeat(56));
+}
+
+main().catch((e) => {
+  console.error('\nFatal error:', e);
+  process.exit(1);
+});

--- a/src/API.ts
+++ b/src/API.ts
@@ -57,7 +57,6 @@ import type {
 } from "./api-clients/client";
 import { PitcherManagerResponse } from "./types";
 
-
 export interface APIOptions {
   apiKey: string;
   config?: Config;
@@ -322,6 +321,7 @@ export class API {
 
   async startVm(id: string, options?: StartVmOptions) {
     const { retryDelay = 200, ...data } = options || {};
+
     const handledResponse = await retryWithDelay(
       async () => {
         const response = await vmStart({

--- a/src/Sandboxes.ts
+++ b/src/Sandboxes.ts
@@ -145,8 +145,11 @@ export class Sandboxes {
 
         try {
           const startResponse = await this.api.startVm(sandboxId, {
-            ...opts,
             retryDelay: 1000,
+            automatic_wakeup_config: opts?.automaticWakeupConfig,
+            hibernation_timeout_seconds: opts?.hibernationTimeoutSeconds,
+            ipcountry: opts?.ipcountry,
+            tier: opts?.vmTier?.name,
           }); // Use 1000ms delay for restart
 
           return new Sandbox(sandboxId, this.api, startResponse, this.tracer);


### PR DESCRIPTION
## Summary

Add a standalone benchmark script to measure time from sandbox creation to port readiness. This allows performance comparison between Pitcher and Pint templates by swapping the template ID. Includes configurable port number, timeout, and run count (default 10 runs). Reports comprehensive statistics: min/max/average/median/p90/p95/p99.

## Changes

- **scripts/benchmark-port-ready.ts**: New benchmark script with CLI via `npm run benchmark`
- **package.json**: Added `benchmark` npm script
- **src/API.ts** and **src/Sandboxes.ts**: Parameter handling fixes for VM startup
- **CHANGELOG.md**: Release 2.4.2 entry

🤖 Generated with Claude Code