### PR TITLE
Add benchmarks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codesandbox/sdk",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codesandbox/sdk",
-      "version": "2.4.1",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "@hey-api/client-fetch": "^0.13.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "postbuild": "rimraf {lib,es}/**/__tests__ {lib,es}/**/*.{spec,test}.{js,d.ts,js.map}",
     "postversion": "git push && git push --tags",
     "prepublish": "npm run build",
+    "benchmark": "vitest run --config vitest.benchmark.config.ts",
     "demo:install": "cd demo && npm install",
     "demo:dev": "cd demo && npm run dev",
     "demo:build": "cd demo && npm run build"

--- a/tests/benchmark/lifecycle.test.ts
+++ b/tests/benchmark/lifecycle.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Sandbox Operation Benchmark
+ *
+ * Measures timing for: create, hibernate, resume, fork, shutdown
+ * Runs N iterations and reports avg, median, p50, p90, p95, p99 per operation.
+ *
+ * Usage:
+ *   CSB_API_KEY=<key> CSB_TEMPLATE_ID=<id> npm run benchmark
+ *   CSB_API_KEY=<key> CSB_TEMPLATE_ID=<id> CSB_ITERATIONS=10 npm run benchmark
+ *
+ * Environment Variables:
+ *   CSB_API_KEY         CodeSandbox API key (required)
+ *   CSB_TEMPLATE_ID     Template ID to fork from (required)
+ *   CSB_BASE_URL        API base URL (default: https://api.codesandbox.io)
+ *   CSB_ITERATIONS      Number of benchmark iterations (default: 5)
+ */
+
+import { test } from "vitest";
+import { CodeSandbox, Sandbox } from "../../src/index.js";
+
+// ---------------------------------------------------------------------------
+// CLI / env argument parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs() {
+  const templateId = process.env.CSB_TEMPLATE_ID;
+  const iterations = process.env.CSB_ITERATIONS
+    ? parseInt(process.env.CSB_ITERATIONS, 10)
+    : 5;
+
+  if (!templateId) {
+    throw new Error("CSB_TEMPLATE_ID environment variable is required.");
+  }
+
+  if (!process.env.CSB_API_KEY) {
+    throw new Error("CSB_API_KEY environment variable is required.");
+  }
+
+  return { templateId, iterations };
+}
+
+// ---------------------------------------------------------------------------
+// SDK initialisation
+// ---------------------------------------------------------------------------
+
+function initSDK(): CodeSandbox {
+  const baseUrl = process.env.CSB_BASE_URL ?? "https://api.codesandbox.io";
+  return new CodeSandbox(process.env.CSB_API_KEY, { baseUrl });
+}
+
+// ---------------------------------------------------------------------------
+// Timing helpers
+// ---------------------------------------------------------------------------
+
+async function timeMs<T>(fn: () => Promise<T>): Promise<[T, number]> {
+  const start = performance.now();
+  const result = await fn();
+  return [result, performance.now() - start];
+}
+
+// ---------------------------------------------------------------------------
+// Statistics
+// ---------------------------------------------------------------------------
+
+interface Stats {
+  samples: number;
+  avg: number;
+  min: number;
+  max: number;
+  median: number;
+  p50: number;
+  p90: number;
+  p95: number;
+  p99: number;
+}
+
+function computeStats(values: number[]): Stats {
+  const sorted = [...values].sort((a, b) => a - b);
+  const n = sorted.length;
+
+  const pct = (p: number) => {
+    const rank = Math.ceil((p / 100) * n);
+    return sorted[Math.min(rank, n) - 1];
+  };
+
+  const avg = values.reduce((sum, v) => sum + v, 0) / n;
+
+  return {
+    samples: n,
+    avg,
+    min: sorted[0],
+    max: sorted[n - 1],
+    median: pct(50),
+    p50: pct(50),
+    p90: pct(90),
+    p95: pct(95),
+    p99: pct(99),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Result storage
+// ---------------------------------------------------------------------------
+
+type OperationName = "create" | "hibernate" | "resume" | "fork" | "shutdown";
+
+const timings: Record<OperationName, number[]> = {
+  create: [],
+  hibernate: [],
+  resume: [],
+  fork: [],
+  shutdown: [],
+};
+
+const errors: Record<OperationName, number> = {
+  create: 0,
+  hibernate: 0,
+  resume: 0,
+  fork: 0,
+  shutdown: 0,
+};
+
+function record(op: OperationName, ms: number) {
+  timings[op].push(ms);
+}
+
+function recordError(op: OperationName) {
+  errors[op]++;
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup helper
+// ---------------------------------------------------------------------------
+
+async function tryCleanup(sdk: CodeSandbox, sandboxId: string) {
+  try {
+    await sdk.sandboxes.shutdown(sandboxId);
+  } catch {
+    /* best effort */
+  }
+  try {
+    await sdk.sandboxes.delete(sandboxId);
+  } catch {
+    /* best effort */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Single benchmark iteration
+// ---------------------------------------------------------------------------
+
+async function runIteration(
+  sdk: CodeSandbox,
+  templateId: string,
+  index: number
+): Promise<void> {
+  console.log(`\n── Iteration ${index + 1} ──────────────────────────────`);
+  let sandbox: Sandbox | undefined;
+  let forkedSandbox: Sandbox | undefined;
+
+  try {
+    // ── create ────────────────────────────────────────────────────────────────
+    process.stdout.write("  create     ");
+    let ms: number;
+    try {
+      [sandbox, ms] = await timeMs(() =>
+        sdk.sandboxes.create({ id: templateId, tags: ["benchmark"] })
+      );
+      record("create", ms);
+      console.log(`${ms.toFixed(0)} ms  ✓  (id: ${sandbox.id})`);
+    } catch (err) {
+      console.log(`FAILED  ✗  ${String(err)}`);
+      recordError("create");
+      return; // Cannot continue without a sandbox
+    }
+
+    const sandboxId = sandbox.id;
+
+    // ── hibernate ─────────────────────────────────────────────────────────────
+    process.stdout.write("  hibernate  ");
+    try {
+      [, ms] = await timeMs(() => sdk.sandboxes.hibernate(sandboxId));
+      record("hibernate", ms);
+      console.log(`${ms.toFixed(0)} ms  ✓`);
+    } catch (err) {
+      console.log(`FAILED  ✗  ${String(err)}`);
+      recordError("hibernate");
+      await tryCleanup(sdk, sandboxId);
+      return;
+    }
+
+    // ── resume ────────────────────────────────────────────────────────────────
+    process.stdout.write("  resume     ");
+    try {
+      [sandbox, ms] = await timeMs(() => sdk.sandboxes.resume(sandboxId));
+      record("resume", ms);
+      console.log(`${ms.toFixed(0)} ms  ✓`);
+    } catch (err) {
+      console.log(`FAILED  ✗  ${String(err)}`);
+      recordError("resume");
+      await tryCleanup(sdk, sandboxId);
+      return;
+    }
+
+    // ── fork ──────────────────────────────────────────────────────────────────
+    process.stdout.write("  fork       ");
+    try {
+      [forkedSandbox, ms] = await timeMs(() =>
+        sdk.sandboxes.create({ id: sandboxId, tags: ["benchmark-fork"] })
+      );
+      record("fork", ms);
+      console.log(`${ms.toFixed(0)} ms  ✓  (fork id: ${forkedSandbox.id})`);
+    } catch (err) {
+      console.log(`FAILED  ✗  ${String(err)}`);
+      recordError("fork");
+    }
+
+    if (forkedSandbox) {
+      await tryCleanup(sdk, forkedSandbox.id);
+    }
+
+    // ── shutdown ──────────────────────────────────────────────────────────────
+    process.stdout.write("  shutdown   ");
+    try {
+      [, ms] = await timeMs(() => sdk.sandboxes.shutdown(sandboxId));
+      record("shutdown", ms);
+      console.log(`${ms.toFixed(0)} ms  ✓`);
+    } catch (err) {
+      console.log(`FAILED  ✗  ${String(err)}`);
+      recordError("shutdown");
+    }
+  } finally {
+    if (sandbox) {
+      await tryCleanup(sdk, sandbox.id);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+const METRIC_NAMES: Record<OperationName, string> = {
+  create:    "sandbox_create_duration",
+  hibernate: "sandbox_hibernate_duration",
+  resume:    "sandbox_resume_duration",
+  fork:      "sandbox_fork_duration",
+  shutdown:  "sandbox_shutdown_duration",
+};
+
+const LABEL_WIDTH = Math.max(...Object.values(METRIC_NAMES).map((n) => n.length)) + 2;
+
+function metricLabel(op: OperationName): string {
+  const name = METRIC_NAMES[op];
+  const dots = ".".repeat(LABEL_WIDTH - name.length);
+  return `${name}${dots}`;
+}
+
+const CYAN = "\x1b[96m";
+const RESET = "\x1b[0m";
+
+function fmtField(key: string, ms: number, valueWidth: number): string {
+  const raw = `${(ms / 1000).toFixed(2)}s`;
+  const padded = raw.padEnd(valueWidth);
+  return `${key}=${CYAN}${padded}${RESET}`;
+}
+
+function printReport() {
+  const ops: OperationName[] = [
+    "create",
+    "hibernate",
+    "resume",
+    "fork",
+    "shutdown",
+  ];
+
+  console.log("\n");
+  console.log("benchmark results");
+
+  for (const op of ops) {
+    const label = metricLabel(op);
+    const samples = timings[op];
+    const errCount = errors[op];
+
+    if (samples.length === 0) {
+      console.log(`${label}: no data  errors=${errCount}`);
+      continue;
+    }
+
+    const s = computeStats(samples);
+
+    const row = [
+      fmtField("avg",   s.avg,    8),
+      fmtField("min",   s.min,    8),
+      fmtField("med",   s.median, 8),
+      fmtField("max",   s.max,    8),
+      fmtField("p(90)", s.p90,    8),
+      fmtField("p(95)", s.p95,    8),
+      fmtField("p(99)", s.p99,    8),
+      `n=${s.samples}`,
+      ...(errCount > 0 ? [`errors=${errCount}`] : []),
+    ].join("  ");
+
+    console.log(`${label}: ${row}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Vitest test entry point
+// ---------------------------------------------------------------------------
+
+const { templateId, iterations } = parseArgs();
+
+// Allow up to 5 minutes per iteration plus overhead
+const TIMEOUT_MS = (iterations + 1) * 5 * 60 * 1000;
+
+test("sandbox benchmark", { timeout: TIMEOUT_MS }, async () => {
+  const sdk = initSDK();
+
+  const baseUrl = process.env.CSB_BASE_URL ?? "https://api.codesandbox.io";
+  console.log("Sandbox Benchmark");
+  console.log(`  Template:   ${templateId}`);
+  console.log(`  Iterations: ${iterations}`);
+  console.log(`  API URL:    ${baseUrl}`);
+
+  for (let i = 0; i < iterations; i++) {
+    await runIteration(sdk, templateId, i);
+  }
+
+  printReport();
+});

--- a/tests/benchmark/lifecycle.test.ts
+++ b/tests/benchmark/lifecycle.test.ts
@@ -1,5 +1,5 @@
 /**
- * Sandbox Operation Benchmark
+ * Sandbox Lifecycle Benchmark
  *
  * Measures timing for: create, hibernate, resume, shutdown, start (after shutdown)
  * Optionally measures time-to-port-ready for: create, resume, start (set CSB_PORT)
@@ -19,7 +19,17 @@
 
 import { test } from "vitest";
 import { CodeSandbox, Sandbox } from "../../src/index.js";
-import { SandboxClient } from "../../src/SandboxClient/index.js";
+import {
+  BenchmarkState,
+  createState,
+  initSDK,
+  measurePortReady,
+  printReport,
+  record,
+  recordError,
+  timeMs,
+  tryCleanup,
+} from "./utils.js";
 
 // ---------------------------------------------------------------------------
 // CLI / env argument parsing
@@ -46,66 +56,7 @@ function parseArgs() {
 }
 
 // ---------------------------------------------------------------------------
-// SDK initialisation
-// ---------------------------------------------------------------------------
-
-function initSDK(): CodeSandbox {
-  const baseUrl = process.env.CSB_BASE_URL ?? "https://api.codesandbox.io";
-  return new CodeSandbox(process.env.CSB_API_KEY, { baseUrl });
-}
-
-// ---------------------------------------------------------------------------
-// Timing helpers
-// ---------------------------------------------------------------------------
-
-async function timeMs<T>(fn: () => Promise<T>): Promise<[T, number]> {
-  const start = performance.now();
-  const result = await fn();
-  return [result, performance.now() - start];
-}
-
-// ---------------------------------------------------------------------------
-// Statistics
-// ---------------------------------------------------------------------------
-
-interface Stats {
-  samples: number;
-  avg: number;
-  min: number;
-  max: number;
-  median: number;
-  p50: number;
-  p90: number;
-  p95: number;
-  p99: number;
-}
-
-function computeStats(values: number[]): Stats {
-  const sorted = [...values].sort((a, b) => a - b);
-  const n = sorted.length;
-
-  const pct = (p: number) => {
-    const rank = Math.ceil((p / 100) * n);
-    return sorted[Math.min(rank, n) - 1];
-  };
-
-  const avg = values.reduce((sum, v) => sum + v, 0) / n;
-
-  return {
-    samples: n,
-    avg,
-    min: sorted[0],
-    max: sorted[n - 1],
-    median: pct(50),
-    p50: pct(50),
-    p90: pct(90),
-    p95: pct(95),
-    p99: pct(99),
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Result storage
+// Operation names
 // ---------------------------------------------------------------------------
 
 type OperationName =
@@ -118,84 +69,19 @@ type OperationName =
   | "resume_to_port_ready"
   | "start_after_shutdown_to_port_ready";
 
-const timings: Record<OperationName, number[]> = {
-  create: [],
-  hibernate: [],
-  resume: [],
-  shutdown: [],
-  start_after_shutdown: [],
-  create_to_port_ready: [],
-  resume_to_port_ready: [],
-  start_after_shutdown_to_port_ready: [],
-};
+const CORE_OPS: OperationName[] = [
+  "create",
+  "hibernate",
+  "resume",
+  "shutdown",
+  "start_after_shutdown",
+];
 
-const errors: Record<OperationName, number> = {
-  create: 0,
-  hibernate: 0,
-  resume: 0,
-  shutdown: 0,
-  start_after_shutdown: 0,
-  create_to_port_ready: 0,
-  resume_to_port_ready: 0,
-  start_after_shutdown_to_port_ready: 0,
-};
-
-function record(op: OperationName, ms: number) {
-  timings[op].push(ms);
-}
-
-function recordError(op: OperationName) {
-  errors[op]++;
-}
-
-// ---------------------------------------------------------------------------
-// Cleanup helper
-// ---------------------------------------------------------------------------
-
-async function tryCleanup(sdk: CodeSandbox, sandboxId: string) {
-  try {
-    await sdk.sandboxes.shutdown(sandboxId);
-  } catch {
-    /* best effort */
-  }
-  try {
-    await sdk.sandboxes.delete(sandboxId);
-  } catch {
-    /* best effort */
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Port readiness helper
-// Measures time from `opStart` until the given port is ready on the sandbox.
-// ---------------------------------------------------------------------------
-
-async function measurePortReady(
-  sandbox: Sandbox,
-  port: number,
-  opName: OperationName,
-  opStart: number
-): Promise<void> {
-  let client: SandboxClient | undefined;
-  try {
-    client = await sandbox.connect();
-    await client.ports.waitForPort(port, { timeoutMs: 120_000 });
-    record(opName, performance.now() - opStart);
-    console.log(
-      `  Port ${port} ready  ${((performance.now() - opStart) / 1000).toFixed(2)}s ✓`
-    );
-  } catch (err) {
-    console.log(`  Port ${port} not ready ✗  ${String(err)}`);
-    recordError(opName);
-  } finally {
-    try {
-      await client?.disconnect();
-      client?.dispose();
-    } catch {
-      /* best effort */
-    }
-  }
-}
+const PORT_OPS: OperationName[] = [
+  "create_to_port_ready",
+  "resume_to_port_ready",
+  "start_after_shutdown_to_port_ready",
+];
 
 // ---------------------------------------------------------------------------
 // Single benchmark iteration
@@ -203,6 +89,7 @@ async function measurePortReady(
 
 async function runIteration(
   sdk: CodeSandbox,
+  state: BenchmarkState,
   templateId: string,
   port: number | undefined,
   index: number
@@ -220,16 +107,16 @@ async function runIteration(
       [sandbox, ms] = await timeMs(() =>
         sdk.sandboxes.create({ id: templateId, tags: ["benchmark"] })
       );
-      record("create", ms);
+      record(state, "create", ms);
       console.log(`  Created  ${(ms / 1000).toFixed(2)}s ✓  (id: ${sandbox.id})`);
     } catch (err) {
       console.log(`  Failed creating ✗  ${String(err)}`);
-      recordError("create");
+      recordError(state, "create");
       return;
     }
 
     if (port) {
-      await measurePortReady(sandbox, port, "create_to_port_ready", opStart!);
+      await measurePortReady(sandbox, port, "create_to_port_ready", opStart!, state);
     }
 
     const sandboxId = sandbox.id;
@@ -238,11 +125,11 @@ async function runIteration(
     console.log("  Hibernating...");
     try {
       [, ms] = await timeMs(() => sdk.sandboxes.hibernate(sandboxId));
-      record("hibernate", ms);
+      record(state, "hibernate", ms);
       console.log(`  Hibernated  ${(ms / 1000).toFixed(2)}s ✓`);
     } catch (err) {
       console.log(`  Failed hibernating ✗  ${String(err)}`);
-      recordError("hibernate");
+      recordError(state, "hibernate");
       await tryCleanup(sdk, sandboxId);
       return;
     }
@@ -252,28 +139,28 @@ async function runIteration(
     try {
       opStart = performance.now();
       [sandbox, ms] = await timeMs(() => sdk.sandboxes.resume(sandboxId));
-      record("resume", ms);
+      record(state, "resume", ms);
       console.log(`  Resumed  ${(ms / 1000).toFixed(2)}s ✓`);
     } catch (err) {
       console.log(`  Failed resuming ✗  ${String(err)}`);
-      recordError("resume");
+      recordError(state, "resume");
       await tryCleanup(sdk, sandboxId);
       return;
     }
 
     if (port) {
-      await measurePortReady(sandbox, port, "resume_to_port_ready", opStart!);
+      await measurePortReady(sandbox, port, "resume_to_port_ready", opStart!, state);
     }
 
     // ── shutdown ──────────────────────────────────────────────────────────────
     console.log("  Shutting down...");
     try {
       [, ms] = await timeMs(() => sdk.sandboxes.shutdown(sandboxId));
-      record("shutdown", ms);
+      record(state, "shutdown", ms);
       console.log(`  Shut down  ${(ms / 1000).toFixed(2)}s ✓`);
     } catch (err) {
       console.log(`  Failed shutting down ✗  ${String(err)}`);
-      recordError("shutdown");
+      recordError(state, "shutdown");
       await tryCleanup(sdk, sandboxId);
       return;
     }
@@ -283,17 +170,17 @@ async function runIteration(
     try {
       opStart = performance.now();
       [sandbox, ms] = await timeMs(() => sdk.sandboxes.resume(sandboxId));
-      record("start_after_shutdown", ms);
+      record(state, "start_after_shutdown", ms);
       console.log(`  Started (after shutdown)  ${(ms / 1000).toFixed(2)}s ✓`);
     } catch (err) {
       console.log(`  Failed starting (after shutdown) ✗  ${String(err)}`);
-      recordError("start_after_shutdown");
+      recordError(state, "start_after_shutdown");
       await tryCleanup(sdk, sandboxId);
       return;
     }
 
     if (port) {
-      await measurePortReady(sandbox, port, "start_after_shutdown_to_port_ready", opStart!);
+      await measurePortReady(sandbox, port, "start_after_shutdown_to_port_ready", opStart!, state);
     }
 
     // ── final shutdown (unmeasured cleanup) ───────────────────────────────────
@@ -309,58 +196,6 @@ async function runIteration(
 }
 
 // ---------------------------------------------------------------------------
-// Report
-// ---------------------------------------------------------------------------
-
-const CYAN = "\x1b[96m";
-const RESET = "\x1b[0m";
-
-function fmtField(key: string, ms: number, valueWidth: number): string {
-  const raw = `${(ms / 1000).toFixed(2)}s`;
-  const padded = raw.padEnd(valueWidth);
-  return `${key}=${CYAN}${padded}${RESET}`;
-}
-
-function printReport(port: number | undefined) {
-  const coreOps: OperationName[] = ["create", "hibernate", "resume", "shutdown", "start_after_shutdown"];
-  const portOps: OperationName[] = ["create_to_port_ready", "resume_to_port_ready", "start_after_shutdown_to_port_ready"];
-  const ops = port ? [...coreOps, ...portOps] : coreOps;
-
-  const labelWidth = Math.max(...ops.map((o) => o.length)) + 2;
-  const label = (op: OperationName) => op + ".".repeat(labelWidth - op.length);
-
-  console.log("\n");
-  console.log("BENCHMARK RESULTS");
-  console.log("─────────────────\n");
-
-  for (const op of ops) {
-    const samples = timings[op];
-    const errCount = errors[op];
-
-    if (samples.length === 0) {
-      if (errCount > 0) console.log(`${label(op)}: no data  errors=${errCount}`);
-      continue;
-    }
-
-    const s = computeStats(samples);
-
-    const row = [
-      fmtField("avg",   s.avg,    8),
-      fmtField("min",   s.min,    8),
-      fmtField("med",   s.median, 8),
-      fmtField("max",   s.max,    8),
-      fmtField("p(90)", s.p90,    8),
-      fmtField("p(95)", s.p95,    8),
-      fmtField("p(99)", s.p99,    8),
-      `n=${s.samples}`,
-      ...(errCount > 0 ? [`errors=${errCount}`] : []),
-    ].join("  ");
-
-    console.log(`${label(op)}: ${row}`);
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Vitest test entry point
 // ---------------------------------------------------------------------------
 
@@ -369,19 +204,21 @@ const { templateId, iterations, port } = parseArgs();
 // Allow up to 5 minutes per iteration plus overhead
 const TIMEOUT_MS = (iterations + 1) * 5 * 60 * 1000;
 
-test("sandbox benchmark", { timeout: TIMEOUT_MS }, async () => {
+test("sandbox lifecycle benchmark", { timeout: TIMEOUT_MS }, async () => {
   const sdk = initSDK();
+  const state = createState([...CORE_OPS, ...PORT_OPS]);
 
   const baseUrl = process.env.CSB_BASE_URL ?? "https://api.codesandbox.io";
-  console.log("Sandbox Benchmark");
+  console.log("Sandbox Lifecycle Benchmark");
   console.log(`  Template:   ${templateId}`);
   console.log(`  Iterations: ${iterations}`);
   console.log(`  API URL:    ${baseUrl}`);
   if (port) console.log(`  Port:       ${port}`);
 
   for (let i = 0; i < iterations; i++) {
-    await runIteration(sdk, templateId, port, i);
+    await runIteration(sdk, state, templateId, port, i);
   }
 
-  printReport(port);
+  const ops = port ? [...CORE_OPS, ...PORT_OPS] : CORE_OPS;
+  printReport(ops, state);
 });

--- a/tests/benchmark/lifecycle.test.ts
+++ b/tests/benchmark/lifecycle.test.ts
@@ -1,22 +1,25 @@
 /**
  * Sandbox Operation Benchmark
  *
- * Measures timing for: create, hibernate, resume, fork, shutdown
+ * Measures timing for: create, hibernate, resume, shutdown, start (after shutdown)
+ * Optionally measures time-to-port-ready for: create, resume, start (set CSB_PORT)
  * Runs N iterations and reports avg, median, p50, p90, p95, p99 per operation.
  *
  * Usage:
  *   CSB_API_KEY=<key> CSB_TEMPLATE_ID=<id> npm run benchmark
- *   CSB_API_KEY=<key> CSB_TEMPLATE_ID=<id> CSB_ITERATIONS=10 npm run benchmark
+ *   CSB_API_KEY=<key> CSB_TEMPLATE_ID=<id> CSB_ITERATIONS=10 CSB_PORT=3000 npm run benchmark
  *
  * Environment Variables:
  *   CSB_API_KEY         CodeSandbox API key (required)
  *   CSB_TEMPLATE_ID     Template ID to fork from (required)
  *   CSB_BASE_URL        API base URL (default: https://api.codesandbox.io)
  *   CSB_ITERATIONS      Number of benchmark iterations (default: 5)
+ *   CSB_PORT            Port to wait for after create/resume/start (optional)
  */
 
 import { test } from "vitest";
 import { CodeSandbox, Sandbox } from "../../src/index.js";
+import { SandboxClient } from "../../src/SandboxClient/index.js";
 
 // ---------------------------------------------------------------------------
 // CLI / env argument parsing
@@ -27,6 +30,9 @@ function parseArgs() {
   const iterations = process.env.CSB_ITERATIONS
     ? parseInt(process.env.CSB_ITERATIONS, 10)
     : 5;
+  const port = process.env.CSB_PORT
+    ? parseInt(process.env.CSB_PORT, 10)
+    : undefined;
 
   if (!templateId) {
     throw new Error("CSB_TEMPLATE_ID environment variable is required.");
@@ -36,7 +42,7 @@ function parseArgs() {
     throw new Error("CSB_API_KEY environment variable is required.");
   }
 
-  return { templateId, iterations };
+  return { templateId, iterations, port };
 }
 
 // ---------------------------------------------------------------------------
@@ -102,22 +108,36 @@ function computeStats(values: number[]): Stats {
 // Result storage
 // ---------------------------------------------------------------------------
 
-type OperationName = "create" | "hibernate" | "resume" | "fork" | "shutdown";
+type OperationName =
+  | "create"
+  | "hibernate"
+  | "resume"
+  | "shutdown"
+  | "start_after_shutdown"
+  | "create_to_port_ready"
+  | "resume_to_port_ready"
+  | "start_after_shutdown_to_port_ready";
 
 const timings: Record<OperationName, number[]> = {
   create: [],
   hibernate: [],
   resume: [],
-  fork: [],
   shutdown: [],
+  start_after_shutdown: [],
+  create_to_port_ready: [],
+  resume_to_port_ready: [],
+  start_after_shutdown_to_port_ready: [],
 };
 
 const errors: Record<OperationName, number> = {
   create: 0,
   hibernate: 0,
   resume: 0,
-  fork: 0,
   shutdown: 0,
+  start_after_shutdown: 0,
+  create_to_port_ready: 0,
+  resume_to_port_ready: 0,
+  start_after_shutdown_to_port_ready: 0,
 };
 
 function record(op: OperationName, ms: number) {
@@ -146,89 +166,141 @@ async function tryCleanup(sdk: CodeSandbox, sandboxId: string) {
 }
 
 // ---------------------------------------------------------------------------
+// Port readiness helper
+// Measures time from `opStart` until the given port is ready on the sandbox.
+// ---------------------------------------------------------------------------
+
+async function measurePortReady(
+  sandbox: Sandbox,
+  port: number,
+  opName: OperationName,
+  opStart: number
+): Promise<void> {
+  let client: SandboxClient | undefined;
+  try {
+    client = await sandbox.connect();
+    await client.ports.waitForPort(port, { timeoutMs: 120_000 });
+    record(opName, performance.now() - opStart);
+    console.log(
+      `  Port ${port} ready  ${((performance.now() - opStart) / 1000).toFixed(2)}s ✓`
+    );
+  } catch (err) {
+    console.log(`  Port ${port} not ready ✗  ${String(err)}`);
+    recordError(opName);
+  } finally {
+    try {
+      await client?.disconnect();
+      client?.dispose();
+    } catch {
+      /* best effort */
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Single benchmark iteration
 // ---------------------------------------------------------------------------
 
 async function runIteration(
   sdk: CodeSandbox,
   templateId: string,
+  port: number | undefined,
   index: number
 ): Promise<void> {
   console.log(`\n── Iteration ${index + 1} ──────────────────────────────`);
   let sandbox: Sandbox | undefined;
-  let forkedSandbox: Sandbox | undefined;
 
   try {
     // ── create ────────────────────────────────────────────────────────────────
-    process.stdout.write("  create     ");
+    console.log("  Creating...");
     let ms: number;
+    let opStart: number;
     try {
+      opStart = performance.now();
       [sandbox, ms] = await timeMs(() =>
         sdk.sandboxes.create({ id: templateId, tags: ["benchmark"] })
       );
       record("create", ms);
-      console.log(`${ms.toFixed(0)} ms  ✓  (id: ${sandbox.id})`);
+      console.log(`  Created  ${(ms / 1000).toFixed(2)}s ✓  (id: ${sandbox.id})`);
     } catch (err) {
-      console.log(`FAILED  ✗  ${String(err)}`);
+      console.log(`  Failed creating ✗  ${String(err)}`);
       recordError("create");
-      return; // Cannot continue without a sandbox
+      return;
+    }
+
+    if (port) {
+      await measurePortReady(sandbox, port, "create_to_port_ready", opStart!);
     }
 
     const sandboxId = sandbox.id;
 
     // ── hibernate ─────────────────────────────────────────────────────────────
-    process.stdout.write("  hibernate  ");
+    console.log("  Hibernating...");
     try {
       [, ms] = await timeMs(() => sdk.sandboxes.hibernate(sandboxId));
       record("hibernate", ms);
-      console.log(`${ms.toFixed(0)} ms  ✓`);
+      console.log(`  Hibernated  ${(ms / 1000).toFixed(2)}s ✓`);
     } catch (err) {
-      console.log(`FAILED  ✗  ${String(err)}`);
+      console.log(`  Failed hibernating ✗  ${String(err)}`);
       recordError("hibernate");
       await tryCleanup(sdk, sandboxId);
       return;
     }
 
     // ── resume ────────────────────────────────────────────────────────────────
-    process.stdout.write("  resume     ");
+    console.log("  Resuming...");
     try {
+      opStart = performance.now();
       [sandbox, ms] = await timeMs(() => sdk.sandboxes.resume(sandboxId));
       record("resume", ms);
-      console.log(`${ms.toFixed(0)} ms  ✓`);
+      console.log(`  Resumed  ${(ms / 1000).toFixed(2)}s ✓`);
     } catch (err) {
-      console.log(`FAILED  ✗  ${String(err)}`);
+      console.log(`  Failed resuming ✗  ${String(err)}`);
       recordError("resume");
       await tryCleanup(sdk, sandboxId);
       return;
     }
 
-    // ── fork ──────────────────────────────────────────────────────────────────
-    process.stdout.write("  fork       ");
-    try {
-      [forkedSandbox, ms] = await timeMs(() =>
-        sdk.sandboxes.create({ id: sandboxId, tags: ["benchmark-fork"] })
-      );
-      record("fork", ms);
-      console.log(`${ms.toFixed(0)} ms  ✓  (fork id: ${forkedSandbox.id})`);
-    } catch (err) {
-      console.log(`FAILED  ✗  ${String(err)}`);
-      recordError("fork");
-    }
-
-    if (forkedSandbox) {
-      await tryCleanup(sdk, forkedSandbox.id);
+    if (port) {
+      await measurePortReady(sandbox, port, "resume_to_port_ready", opStart!);
     }
 
     // ── shutdown ──────────────────────────────────────────────────────────────
-    process.stdout.write("  shutdown   ");
+    console.log("  Shutting down...");
     try {
       [, ms] = await timeMs(() => sdk.sandboxes.shutdown(sandboxId));
       record("shutdown", ms);
-      console.log(`${ms.toFixed(0)} ms  ✓`);
+      console.log(`  Shut down  ${(ms / 1000).toFixed(2)}s ✓`);
     } catch (err) {
-      console.log(`FAILED  ✗  ${String(err)}`);
+      console.log(`  Failed shutting down ✗  ${String(err)}`);
       recordError("shutdown");
+      await tryCleanup(sdk, sandboxId);
+      return;
     }
+
+    // ── start (after shutdown) ────────────────────────────────────────────────
+    console.log("  Starting...");
+    try {
+      opStart = performance.now();
+      [sandbox, ms] = await timeMs(() => sdk.sandboxes.resume(sandboxId));
+      record("start_after_shutdown", ms);
+      console.log(`  Started (after shutdown)  ${(ms / 1000).toFixed(2)}s ✓`);
+    } catch (err) {
+      console.log(`  Failed starting (after shutdown) ✗  ${String(err)}`);
+      recordError("start_after_shutdown");
+      await tryCleanup(sdk, sandboxId);
+      return;
+    }
+
+    if (port) {
+      await measurePortReady(sandbox, port, "start_after_shutdown_to_port_ready", opStart!);
+    }
+
+    // ── final shutdown (unmeasured cleanup) ───────────────────────────────────
+    console.log("  Shutting down (cleanup)...");
+    await tryCleanup(sdk, sandboxId);
+    sandbox = undefined;
+    console.log("  Done");
   } finally {
     if (sandbox) {
       await tryCleanup(sdk, sandbox.id);
@@ -240,22 +312,6 @@ async function runIteration(
 // Report
 // ---------------------------------------------------------------------------
 
-const METRIC_NAMES: Record<OperationName, string> = {
-  create:    "sandbox_create_duration",
-  hibernate: "sandbox_hibernate_duration",
-  resume:    "sandbox_resume_duration",
-  fork:      "sandbox_fork_duration",
-  shutdown:  "sandbox_shutdown_duration",
-};
-
-const LABEL_WIDTH = Math.max(...Object.values(METRIC_NAMES).map((n) => n.length)) + 2;
-
-function metricLabel(op: OperationName): string {
-  const name = METRIC_NAMES[op];
-  const dots = ".".repeat(LABEL_WIDTH - name.length);
-  return `${name}${dots}`;
-}
-
 const CYAN = "\x1b[96m";
 const RESET = "\x1b[0m";
 
@@ -265,25 +321,24 @@ function fmtField(key: string, ms: number, valueWidth: number): string {
   return `${key}=${CYAN}${padded}${RESET}`;
 }
 
-function printReport() {
-  const ops: OperationName[] = [
-    "create",
-    "hibernate",
-    "resume",
-    "fork",
-    "shutdown",
-  ];
+function printReport(port: number | undefined) {
+  const coreOps: OperationName[] = ["create", "hibernate", "resume", "shutdown", "start_after_shutdown"];
+  const portOps: OperationName[] = ["create_to_port_ready", "resume_to_port_ready", "start_after_shutdown_to_port_ready"];
+  const ops = port ? [...coreOps, ...portOps] : coreOps;
+
+  const labelWidth = Math.max(...ops.map((o) => o.length)) + 2;
+  const label = (op: OperationName) => op + ".".repeat(labelWidth - op.length);
 
   console.log("\n");
-  console.log("benchmark results");
+  console.log("BENCHMARK RESULTS");
+  console.log("─────────────────\n");
 
   for (const op of ops) {
-    const label = metricLabel(op);
     const samples = timings[op];
     const errCount = errors[op];
 
     if (samples.length === 0) {
-      console.log(`${label}: no data  errors=${errCount}`);
+      if (errCount > 0) console.log(`${label(op)}: no data  errors=${errCount}`);
       continue;
     }
 
@@ -301,7 +356,7 @@ function printReport() {
       ...(errCount > 0 ? [`errors=${errCount}`] : []),
     ].join("  ");
 
-    console.log(`${label}: ${row}`);
+    console.log(`${label(op)}: ${row}`);
   }
 }
 
@@ -309,7 +364,7 @@ function printReport() {
 // Vitest test entry point
 // ---------------------------------------------------------------------------
 
-const { templateId, iterations } = parseArgs();
+const { templateId, iterations, port } = parseArgs();
 
 // Allow up to 5 minutes per iteration plus overhead
 const TIMEOUT_MS = (iterations + 1) * 5 * 60 * 1000;
@@ -322,10 +377,11 @@ test("sandbox benchmark", { timeout: TIMEOUT_MS }, async () => {
   console.log(`  Template:   ${templateId}`);
   console.log(`  Iterations: ${iterations}`);
   console.log(`  API URL:    ${baseUrl}`);
+  if (port) console.log(`  Port:       ${port}`);
 
   for (let i = 0; i < iterations; i++) {
-    await runIteration(sdk, templateId, i);
+    await runIteration(sdk, templateId, port, i);
   }
 
-  printReport();
+  printReport(port);
 });

--- a/tests/benchmark/start-from-archive.test.ts
+++ b/tests/benchmark/start-from-archive.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Sandbox Start-from-Archive Benchmark
+ *
+ * Measures how long it takes to resume a sandbox from archived state and
+ * optionally wait for a port to be ready.
+ *
+ * The sandbox must already be in an archived state before running. Each
+ * iteration resumes the sandbox, records timings, then re-archives it for
+ * the next iteration.
+ *
+ * Usage:
+ *   CSB_API_KEY=<key> CSB_SANDBOX_ID=<id> CSB_PORT=3000 npm run benchmark -- --project start-from-archive
+ *
+ * Environment Variables:
+ *   CSB_API_KEY         CodeSandbox API key (required)
+ *   CSB_SANDBOX_ID      ID of the archived sandbox (required)
+ *   CSB_PORT            Port to wait for after resume (optional)
+ *   CSB_BASE_URL        API base URL (default: https://api.codesandbox.io)
+ *   CSB_ITERATIONS      Number of benchmark iterations (default: 5)
+ */
+
+import { test } from "vitest";
+import { CodeSandbox, Sandbox } from "../../src/index.js";
+import {
+  BenchmarkState,
+  createState,
+  initSDK,
+  measurePortReady,
+  printReport,
+  record,
+  recordError,
+  timeMs,
+} from "./utils.js";
+
+// ---------------------------------------------------------------------------
+// CLI / env argument parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs() {
+  const sandboxId = process.env.CSB_SANDBOX_ID;
+  const iterations = process.env.CSB_ITERATIONS
+    ? parseInt(process.env.CSB_ITERATIONS, 10)
+    : 5;
+  const port = process.env.CSB_PORT
+    ? parseInt(process.env.CSB_PORT, 10)
+    : undefined;
+
+  if (!sandboxId) {
+    throw new Error("CSB_SANDBOX_ID environment variable is required.");
+  }
+
+  if (!process.env.CSB_API_KEY) {
+    throw new Error("CSB_API_KEY environment variable is required.");
+  }
+
+  return { sandboxId, iterations, port };
+}
+
+// ---------------------------------------------------------------------------
+// Operation names
+// ---------------------------------------------------------------------------
+
+type OperationName = "start_from_archive" | "start_from_archive_to_port_ready";
+
+const CORE_OPS: OperationName[] = ["start_from_archive"];
+const PORT_OPS: OperationName[] = ["start_from_archive_to_port_ready"];
+
+// ---------------------------------------------------------------------------
+// Single benchmark iteration
+// ---------------------------------------------------------------------------
+
+async function runIteration(
+  sdk: CodeSandbox,
+  state: BenchmarkState,
+  sandboxId: string,
+  port: number | undefined,
+  index: number
+): Promise<void> {
+  console.log(`\n── Iteration ${index + 1} ──────────────────────────────`);
+
+  // ── resume from archive ───────────────────────────────────────────────────
+  console.log("  Resuming from archive...");
+  let sandbox: Sandbox;
+  let opStart: number;
+  let ms: number;
+  try {
+    opStart = performance.now();
+    [sandbox, ms] = await timeMs(() => sdk.sandboxes.resume(sandboxId));
+    record(state, "start_from_archive", ms);
+    console.log(`  Started from archive  ${(ms / 1000).toFixed(2)}s ✓`);
+  } catch (err) {
+    console.log(`  Failed to start from archive ✗  ${String(err)}`);
+    recordError(state, "start_from_archive");
+    return;
+  }
+
+  // ── port readiness ────────────────────────────────────────────────────────
+  if (port) {
+    await measurePortReady(sandbox, port, "start_from_archive_to_port_ready", opStart, state);
+  }
+
+  // ── re-archive for next iteration ─────────────────────────────────────────
+  if (index < iterations - 1) {
+    console.log("  Archiving...");
+    try {
+      await sdk.sandboxes.hibernate(sandboxId);
+      console.log("  Archived ✓");
+    } catch (err) {
+      console.log(`  Failed to archive ✗  ${String(err)}`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Vitest test entry point
+// ---------------------------------------------------------------------------
+
+const { sandboxId, iterations, port } = parseArgs();
+
+// Allow up to 5 minutes per iteration plus overhead
+const TIMEOUT_MS = (iterations + 1) * 5 * 60 * 1000;
+
+test("sandbox start-from-archive benchmark", { timeout: TIMEOUT_MS }, async () => {
+  const sdk = initSDK();
+  const state = createState([...CORE_OPS, ...PORT_OPS]);
+
+  const baseUrl = process.env.CSB_BASE_URL ?? "https://api.codesandbox.io";
+  console.log("Sandbox Start-from-Archive Benchmark");
+  console.log(`  Sandbox ID: ${sandboxId}`);
+  console.log(`  Iterations: ${iterations}`);
+  console.log(`  API URL:    ${baseUrl}`);
+  if (port) console.log(`  Port:       ${port}`);
+
+  for (let i = 0; i < iterations; i++) {
+    await runIteration(sdk, state, sandboxId, port, i);
+  }
+
+  const ops = port ? [...CORE_OPS, ...PORT_OPS] : CORE_OPS;
+  printReport(ops, state);
+});

--- a/tests/benchmark/utils.ts
+++ b/tests/benchmark/utils.ts
@@ -1,0 +1,183 @@
+import { CodeSandbox, Sandbox } from "../../src/index.js";
+import { SandboxClient } from "../../src/SandboxClient/index.js";
+
+// ---------------------------------------------------------------------------
+// SDK initialisation
+// ---------------------------------------------------------------------------
+
+export function initSDK(): CodeSandbox {
+  const baseUrl = process.env.CSB_BASE_URL ?? "https://api.codesandbox.io";
+  return new CodeSandbox(process.env.CSB_API_KEY, { baseUrl });
+}
+
+// ---------------------------------------------------------------------------
+// Timing helpers
+// ---------------------------------------------------------------------------
+
+export async function timeMs<T>(fn: () => Promise<T>): Promise<[T, number]> {
+  const start = performance.now();
+  const result = await fn();
+  return [result, performance.now() - start];
+}
+
+// ---------------------------------------------------------------------------
+// Statistics
+// ---------------------------------------------------------------------------
+
+export interface Stats {
+  samples: number;
+  avg: number;
+  min: number;
+  max: number;
+  median: number;
+  p50: number;
+  p90: number;
+  p95: number;
+  p99: number;
+}
+
+export function computeStats(values: number[]): Stats {
+  const sorted = [...values].sort((a, b) => a - b);
+  const n = sorted.length;
+
+  const pct = (p: number) => {
+    const rank = Math.ceil((p / 100) * n);
+    return sorted[Math.min(rank, n) - 1];
+  };
+
+  const avg = values.reduce((sum, v) => sum + v, 0) / n;
+
+  return {
+    samples: n,
+    avg,
+    min: sorted[0],
+    max: sorted[n - 1],
+    median: pct(50),
+    p50: pct(50),
+    p90: pct(90),
+    p95: pct(95),
+    p99: pct(99),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark state
+// ---------------------------------------------------------------------------
+
+export interface BenchmarkState {
+  timings: Record<string, number[]>;
+  errors: Record<string, number>;
+}
+
+export function createState(ops: readonly string[]): BenchmarkState {
+  return {
+    timings: Object.fromEntries(ops.map((op) => [op, []])),
+    errors: Object.fromEntries(ops.map((op) => [op, 0])),
+  };
+}
+
+export function record(state: BenchmarkState, op: string, ms: number): void {
+  state.timings[op].push(ms);
+}
+
+export function recordError(state: BenchmarkState, op: string): void {
+  state.errors[op]++;
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup helper
+// ---------------------------------------------------------------------------
+
+export async function tryCleanup(sdk: CodeSandbox, sandboxId: string): Promise<void> {
+  try {
+    await sdk.sandboxes.shutdown(sandboxId);
+  } catch {
+    /* best effort */
+  }
+  try {
+    await sdk.sandboxes.delete(sandboxId);
+  } catch {
+    /* best effort */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Port readiness helper
+// Measures time from `opStart` until the given port is ready on the sandbox.
+// ---------------------------------------------------------------------------
+
+export async function measurePortReady(
+  sandbox: Sandbox,
+  port: number,
+  opName: string,
+  opStart: number,
+  state: BenchmarkState
+): Promise<void> {
+  let client: SandboxClient | undefined;
+  try {
+    client = await sandbox.connect();
+    await client.ports.waitForPort(port, { timeoutMs: 120_000 });
+    record(state, opName, performance.now() - opStart);
+    console.log(
+      `  Port ${port} ready  ${((performance.now() - opStart) / 1000).toFixed(2)}s ✓`
+    );
+  } catch (err) {
+    console.log(`  Port ${port} not ready ✗  ${String(err)}`);
+    recordError(state, opName);
+  } finally {
+    try {
+      await client?.disconnect();
+      client?.dispose();
+    } catch {
+      /* best effort */
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+const CYAN = "\x1b[96m";
+const RESET = "\x1b[0m";
+
+export function fmtField(key: string, ms: number, valueWidth: number): string {
+  const raw = `${(ms / 1000).toFixed(2)}s`;
+  const padded = raw.padEnd(valueWidth);
+  return `${key}=${CYAN}${padded}${RESET}`;
+}
+
+export function printReport(ops: readonly string[], state: BenchmarkState): void {
+  const labelWidth = Math.max(...ops.map((o) => o.length)) + 2;
+  const label = (op: string) => op + ".".repeat(labelWidth - op.length);
+
+  console.log("\n");
+  console.log("BENCHMARK RESULTS");
+  console.log("─────────────────\n");
+
+  for (const op of ops) {
+    const samples = state.timings[op];
+    const errCount = state.errors[op];
+
+    if (samples.length === 0) {
+      if (errCount > 0) console.log(`${label(op)}: no data  errors=${errCount}`);
+      continue;
+    }
+
+    const s = computeStats(samples);
+
+    const row = [
+      fmtField("avg",   s.avg,    8),
+      fmtField("min",   s.min,    8),
+      fmtField("med",   s.median, 8),
+      fmtField("max",   s.max,    8),
+      fmtField("p(90)", s.p90,    8),
+      fmtField("p(95)", s.p95,    8),
+      fmtField("p(99)", s.p99,    8),
+      `n=${s.samples}`,
+      ...(errCount > 0 ? [`errors=${errCount}`] : []),
+    ].join("  ");
+
+    console.log(`${label(op)}: ${row}`);
+  }
+}

--- a/vitest.benchmark.config.ts
+++ b/vitest.benchmark.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/benchmark/**/*.test.ts"],
+    reporters: ["verbose"],
+  },
+  define: {
+    CSB_SDK_VERSION: JSON.stringify("2.5.0"),
+  },
+});


### PR DESCRIPTION
This PR adds a test script that benchmarks the lifecycle operation of sandbox. It works with both pitcher and pint sandboxes.

NOTE: This PR is mostly AI generated

fixes https://linear.app/together-ai/issue/CSB-1118/add-sdk-based-tests-for-comparision-with-pitcher-and-pint