### PR TITLE
ci: publish to npm via trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,13 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Creates/updates the release PR and, when merged, tags and publishes a
+      # GitHub Release. Publishing to npm is handled separately by release.yml,
+      # which is triggered by the `release: published` event.
+      #
+      # The release is created with RELEASE_PLEASE_TOKEN (a PAT) rather than the
+      # default GITHUB_TOKEN so that the resulting release event can trigger
+      # release.yml.
       - uses: googleapis/release-please-action@v4
         id: release
         with:
@@ -20,23 +27,3 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           bump-minor-pre-major: true
           bump-patch-for-minor-pre-major: true
-
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Build
-        run: npm run build
-
-      - name: Publish to NPM
-        if: ${{ steps.release.outputs.release_created }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --no-git-checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+# Publishes to npm using Trusted Publishing (OIDC). No NPM_TOKEN secret is
+# used — npm verifies the workflow's OIDC identity instead. The npm package
+# must be configured to trust this exact workflow file (release.yml).
+#
+# Triggered when Release Please publishes a GitHub Release (see
+# release-please.yml). Because Release Please creates the release with a PAT
+# (RELEASE_PLEASE_TOKEN) rather than the default GITHUB_TOKEN, this
+# `release: published` event is able to trigger this workflow.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write # Required for npm Trusted Publishing (OIDC)
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
+
+      # Trusted Publishing requires npm >= 11.5.1, newer than what ships with
+      # Node 20.
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --no-git-checks


### PR DESCRIPTION
## What

Switch npm publishing from a long-lived `NPM_TOKEN` to **Trusted Publishing (OIDC)**.

- **New `.github/workflows/release.yml`** — publishes to npm via OIDC. Triggered by the `release: published` event, with `id-token: write` permission, updates npm to a version that supports trusted publishing (≥ 11.5.1), and runs `npm publish` with no `NODE_AUTH_TOKEN`.
- **`release-please.yml`** — slimmed to only create the release PR / GitHub Release. Build + publish moved to `release.yml`.

## Flow

1. Push to `main` → Release Please opens/updates a release PR.
2. Merge the PR → Release Please tags and publishes a GitHub Release → that `release: published` event triggers `release.yml`, which publishes to npm.

This works because Release Please creates the release with `RELEASE_PLEASE_TOKEN` (a PAT), so the release event can trigger downstream workflows (the default `GITHUB_TOKEN` would not).

## Before merging
- Confirm the npm trusted publisher is configured for workflow filename **`release.yml`** on `codesandbox/codesandbox-sdk` — the OIDC claim must match exactly.
- The `NPM_TOKEN` secret is now unused and can be removed after a successful publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)